### PR TITLE
feature: 카테고리 검색 구현, userId resolver 해결, querydsl 추가

### DIFF
--- a/linkmind/build.gradle
+++ b/linkmind/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.2.0'
@@ -21,6 +27,7 @@ repositories {
 	mavenCentral()
 }
 
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -42,6 +49,12 @@ dependencies {
 	implementation 'com.squareup.okhttp3:okhttp:4.10.0'  // Firebase 서버로 푸시 메시지 전송 시 필요
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	//Query DSL
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/linkmind/src/main/java/com/app/toaster/config/JpaQueryFactoryConfig.java
+++ b/linkmind/src/main/java/com/app/toaster/config/JpaQueryFactoryConfig.java
@@ -1,0 +1,17 @@
+package com.app.toaster.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Configuration
+public class JpaQueryFactoryConfig {
+
+	@Bean
+	JPAQueryFactory jpaQueryFactory(EntityManager em) {
+		return new JPAQueryFactory(em);
+	}
+}

--- a/linkmind/src/main/java/com/app/toaster/config/WebConfig.java
+++ b/linkmind/src/main/java/com/app/toaster/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.app.toaster.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+	private final UserIdResolver userIdResolver;
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(userIdResolver);
+	}
+}

--- a/linkmind/src/main/java/com/app/toaster/controller/AuthController.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/AuthController.java
@@ -44,6 +44,7 @@ public class AuthController {
 	@PostMapping("/sign-out")
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResponse signOut(@UserId Long userId) {
+		System.out.println(userId);
 		authService.signOut(userId);
 		return ApiResponse.success(Success.SIGNOUT_SUCCESS);
 	}

--- a/linkmind/src/main/java/com/app/toaster/controller/CategoryController.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/CategoryController.java
@@ -1,0 +1,29 @@
+package com.app.toaster.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.app.toaster.common.dto.ApiResponse;
+import com.app.toaster.domain.Category;
+import com.app.toaster.infrastructure.CategoryRepository;
+import com.app.toaster.service.search.SearchService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/category")
+public class CategoryController {
+	private final SearchService searchService;
+
+	@GetMapping("/search")
+	public ApiResponse searchProducts(@RequestHeader Long userId ,@RequestParam("query") String query){
+		return searchService.searchCategorytitle(userId,query);
+	}
+}

--- a/linkmind/src/main/java/com/app/toaster/controller/MainController.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/MainController.java
@@ -1,8 +1,6 @@
 package com.app.toaster.controller;
 
-import java.util.List;
-
-import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,20 +8,19 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.app.toaster.common.dto.ApiResponse;
-import com.app.toaster.domain.Category;
-import com.app.toaster.infrastructure.CategoryRepository;
 import com.app.toaster.service.search.SearchService;
+import com.app.toaster.service.toast.ToastService;
 
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/category")
-public class CategoryController {
+@RequestMapping("/main")
+public class MainController {
 	private final SearchService searchService;
 
 	@GetMapping("/search")
 	public ApiResponse searchProducts(@RequestHeader Long userId ,@RequestParam("query") String query){
-		return searchService.searchCategoryTitle(userId,query);
+		return searchService.searchMain(userId,query);
 	}
 }

--- a/linkmind/src/main/java/com/app/toaster/controller/ToastController.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/ToastController.java
@@ -34,7 +34,7 @@ public class ToastController {
 	@ResponseStatus(HttpStatus.CREATED)
 	public ApiResponse createToast(
 		@RequestHeader("userId") Long userId,
-		@RequestBody @Valid SaveToastDto requestDto
+		@RequestBody SaveToastDto requestDto
 	) {
 		toastService.createToast(userId, requestDto);
 		return ApiResponse.success(Success.CREATE_TOAST_SUCCESS);

--- a/linkmind/src/main/java/com/app/toaster/controller/response/search/CategoryResult.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/response/search/CategoryResult.java
@@ -1,0 +1,7 @@
+package com.app.toaster.controller.response.search;
+
+public record CategoryResult(Long categoryId, String title) {
+	public static CategoryResult of(Long categoryId, String title){
+		return new CategoryResult(categoryId, title);
+	}
+}

--- a/linkmind/src/main/java/com/app/toaster/controller/response/search/SearchCategoryResult.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/response/search/SearchCategoryResult.java
@@ -1,0 +1,11 @@
+package com.app.toaster.controller.response.search;
+
+import java.util.List;
+
+import com.app.toaster.domain.Category;
+
+public record SearchCategoryResult(List<CategoryResult> categories) {
+	public static SearchCategoryResult of(List<CategoryResult> categories){
+		return new SearchCategoryResult(categories);
+	}
+}

--- a/linkmind/src/main/java/com/app/toaster/controller/response/search/SearchMainResult.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/response/search/SearchMainResult.java
@@ -1,0 +1,9 @@
+package com.app.toaster.controller.response.search;
+
+import java.util.List;
+
+public record SearchMainResult(List<ToastResult> toasts, List<CategoryResult> categories) {
+	public static SearchMainResult of(List<ToastResult> toasts, List<CategoryResult> categories){
+		return new SearchMainResult(toasts,categories);
+	}
+}

--- a/linkmind/src/main/java/com/app/toaster/controller/response/search/ToastResult.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/response/search/ToastResult.java
@@ -1,0 +1,7 @@
+package com.app.toaster.controller.response.search;
+
+public record ToastResult(Long toastId, String title) {
+	public static ToastResult of(Long toastId, String title){
+		return new ToastResult(toastId, title);
+	}
+}

--- a/linkmind/src/main/java/com/app/toaster/domain/Category.java
+++ b/linkmind/src/main/java/com/app/toaster/domain/Category.java
@@ -5,9 +5,11 @@ import java.util.List;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -24,9 +26,15 @@ public class Category {
 
 	private String title;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	private User user;
+
+
+
 	@Builder
-	public Category(String title) {
+	public Category(String title, User user) {
 		this.title = title;
+		this.user = user;
 	}
 
 }

--- a/linkmind/src/main/java/com/app/toaster/exception/Success.java
+++ b/linkmind/src/main/java/com/app/toaster/exception/Success.java
@@ -25,6 +25,7 @@ public enum Success {
 	SIGNOUT_SUCCESS(HttpStatus.OK, "로그아웃 성공"),
 	DELETE_USER_SUCCESS(HttpStatus.OK, "유저 삭제 성공"),
 	DELETE_TOAST_SUCCESS(HttpStatus.OK, "토스트 삭제 성공"),
+	SEARCH_SUCCESS(HttpStatus.OK, "검색 성공"),
 
 
 	UPDATE_ISREAD_SUCCESS(HttpStatus.OK, "열람여부 수정 완료"),
@@ -33,6 +34,7 @@ public enum Success {
 	/**
 	 * 204 NO_CONTENT
 	 */
+	SEARCH_SUCCESS_BUT_IS_EMPTY(HttpStatus.NO_CONTENT, "검색에 성공했지만 조회된 내용이 없습니다.")
 
 	;
 

--- a/linkmind/src/main/java/com/app/toaster/infrastructure/CategoryRepository.java
+++ b/linkmind/src/main/java/com/app/toaster/infrastructure/CategoryRepository.java
@@ -1,5 +1,6 @@
 package com.app.toaster.infrastructure;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,10 @@ import org.springframework.data.jpa.repository.Query;
 import com.app.toaster.domain.Category;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+	@Query("SELECT c FROM Category c WHERE " +
+		"c.user.userId = :userId and " +
+		"c.title LIKE CONCAT('%',:query, '%')"
+	)
+	List<Category> searchCategoriesByQuery(Long userId,String query);
 }

--- a/linkmind/src/main/java/com/app/toaster/infrastructure/ToastRepository.java
+++ b/linkmind/src/main/java/com/app/toaster/infrastructure/ToastRepository.java
@@ -1,7 +1,11 @@
 package com.app.toaster.infrastructure;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.app.toaster.domain.Category;
 import com.app.toaster.domain.Toast;
 
 public interface ToastRepository extends JpaRepository<Toast, Long> {

--- a/linkmind/src/main/java/com/app/toaster/infrastructure/ToastRepository.java
+++ b/linkmind/src/main/java/com/app/toaster/infrastructure/ToastRepository.java
@@ -9,4 +9,10 @@ import com.app.toaster.domain.Category;
 import com.app.toaster.domain.Toast;
 
 public interface ToastRepository extends JpaRepository<Toast, Long> {
+
+	@Query("SELECT t FROM Toast t WHERE " +
+		"t.user.userId = :userId and " +
+		"t.title LIKE CONCAT('%',:query, '%')"
+	)
+	List<Toast> searchToastsByQuery(Long userId, String query);
 }

--- a/linkmind/src/main/java/com/app/toaster/service/auth/AuthService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/AuthService.java
@@ -28,8 +28,8 @@ public class AuthService {
 	private final UserRepository userRepository;
 
 
-	private final Long TOKEN_EXPIRATION_TIME_ACCESS = 100 * 24 * 60 * 60 * 1000L;
-	private final Long TOKEN_EXPIRATION_TIME_REFRESH = 200 * 24 * 60 * 60 * 1000L;
+	private final Long TOKEN_EXPIRATION_TIME_ACCESS = 1 * 60 * 1000L;
+	private final Long TOKEN_EXPIRATION_TIME_REFRESH = 3 * 60 * 1000L;
 
 	@Transactional
 	public SignInResponseDto signIn(String socialAccessToken, SignInRequestDto requestDto) {

--- a/linkmind/src/main/java/com/app/toaster/service/auth/AuthService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/AuthService.java
@@ -49,6 +49,8 @@ public class AuthService {
 
 		User user = userRepository.findBySocialIdAndSocialType(socialId, socialType)
 			.orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
+		System.out.println(user);
+		System.out.println(user.getUserId());
 
 		// jwt 발급 (액세스 토큰, 리프레쉬 토큰)
 		String accessToken = jwtService.issuedToken(String.valueOf(user.getUserId()), TOKEN_EXPIRATION_TIME_ACCESS);
@@ -79,6 +81,8 @@ public class AuthService {
 
 	@Transactional
 	public void signOut(Long userId) {
+		System.out.println("여기???");
+		System.out.println(userId);
 		User user = userRepository.findByUserId(userId)
 			.orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
 		user.updateRefreshToken(null);

--- a/linkmind/src/main/java/com/app/toaster/service/search/SearchService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/search/SearchService.java
@@ -8,7 +8,10 @@ import org.springframework.stereotype.Service;
 import com.app.toaster.common.dto.ApiResponse;
 import com.app.toaster.controller.response.search.CategoryResult;
 import com.app.toaster.controller.response.search.SearchCategoryResult;
+import com.app.toaster.controller.response.search.SearchMainResult;
+import com.app.toaster.controller.response.search.ToastResult;
 import com.app.toaster.domain.Category;
+import com.app.toaster.domain.Toast;
 import com.app.toaster.domain.User;
 import com.app.toaster.exception.Error;
 import com.app.toaster.exception.Success;
@@ -28,7 +31,7 @@ public class SearchService {
 	private final UserRepository userRepository;
 	private final CategoryRepository categoryRepository;
 
-	public ApiResponse<SearchCategoryResult> searchCategorytitle(Long userId, String searchParam){
+	public ApiResponse<SearchCategoryResult> searchCategoryTitle(Long userId, String searchParam){
 		User presentUser =  userRepository.findByUserId(userId).orElseThrow(
 			()-> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage())
 		);
@@ -42,6 +45,26 @@ public class SearchService {
 			searchCategoryList.stream().map(
 				category -> CategoryResult.of(category.getCategoryId(), category.getTitle()))
 				.collect(Collectors.toList())));
+	}
+
+	public ApiResponse<SearchMainResult> searchMain(Long userId, String searchParam){
+		User presentUser =  userRepository.findByUserId(userId).orElseThrow(
+			()-> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage())
+		);
+		List<Toast> searchToastList = toastRepository.searchToastsByQuery(userId, searchParam);
+		List<Category> searchCategoryList = categoryRepository.searchCategoriesByQuery(userId, searchParam);
+
+		if (searchToastList.isEmpty() && searchCategoryList.isEmpty()){
+			return ApiResponse.success(Success.SEARCH_SUCCESS_BUT_IS_EMPTY,null);
+		}
+		return ApiResponse.success(Success.SEARCH_SUCCESS, SearchMainResult.of(
+			searchToastList.stream().map(
+					toast -> ToastResult.of(toast.getId(), toast.getTitle()))
+				.collect(Collectors.toList()),
+			searchCategoryList.stream().map(
+					category -> CategoryResult.of(category.getCategoryId(), category.getTitle()))
+				.collect(Collectors.toList())
+			));
 	}
 
 }

--- a/linkmind/src/main/java/com/app/toaster/service/search/SearchService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/search/SearchService.java
@@ -1,0 +1,47 @@
+package com.app.toaster.service.search;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.app.toaster.common.dto.ApiResponse;
+import com.app.toaster.controller.response.search.CategoryResult;
+import com.app.toaster.controller.response.search.SearchCategoryResult;
+import com.app.toaster.domain.Category;
+import com.app.toaster.domain.User;
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.Success;
+import com.app.toaster.exception.model.CustomException;
+import com.app.toaster.exception.model.NotFoundException;
+import com.app.toaster.infrastructure.CategoryRepository;
+import com.app.toaster.infrastructure.ToastRepository;
+import com.app.toaster.infrastructure.UserRepository;
+import com.google.protobuf.Api;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+	private final ToastRepository toastRepository;
+	private final UserRepository userRepository;
+	private final CategoryRepository categoryRepository;
+
+	public ApiResponse<SearchCategoryResult> searchCategorytitle(Long userId, String searchParam){
+		User presentUser =  userRepository.findByUserId(userId).orElseThrow(
+			()-> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage())
+		);
+		List<Category> searchCategoryList = categoryRepository.searchCategoriesByQuery(userId, searchParam);
+
+		if (searchCategoryList.isEmpty()){
+			return ApiResponse.success(Success.SEARCH_SUCCESS_BUT_IS_EMPTY,null);
+		}
+
+		return ApiResponse.success(Success.SEARCH_SUCCESS, SearchCategoryResult.of(
+			searchCategoryList.stream().map(
+				category -> CategoryResult.of(category.getCategoryId(), category.getTitle()))
+				.collect(Collectors.toList())));
+	}
+
+}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #14 

## 📋 구현 기능 명세
- [x] userId resolver webconfig 등록
- [x] querydsl 의존성 추가
- [x] 카테고리 제목으로 검색 구현  

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
webconfig에 userId resolver를 등록해주는 걸 깜빡해서 상욱이형을 폭행함..
나중에 열람 개수 세는 것을 할 때 query 3방 다 일일이 날려서 종합하는 것보다 querydsl을 사용해서 한번에 로직을 종합해보면 어떻겠는가! 싶어서 등록해줬습니다.
처음에 toast를 이용해서 userid,toastid,categoryid를 동시에 핸들링해서 검색을 구현하려다가 생각해보니 toast를 안 만드는 카테고리도 조회가 돼야하는 것을 깨달아서 category로 다시 수정했습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지
검색로직에서 주의해야하는 점들이 많을 것 같은데 일단 firstcommit으로 남깁니다..! 알려주시면 vaildation에서 필요한 요구사항들 핸들링해보겠습니당 🙈

- 개발하면서 어떤 점이 궁금했는지
조회할 때 method 잘못요청했을 때 오류 핸들링 왜 안먹는지 확인하겠습니당. 예로 get인데 post날리면 그냥 bad request로만 뜨길래 정확히 확인해서 수정하면 클라도 우리도 좋을 것 같습니당! 
그리고 main에서 카테고리랑, toast 이름을 동시에 조회를 해와야하는데.. 흠 뭔가 깔끔하게 짜보고싶다는 느낌이 드네용;ㅋㅋ 이건 연구해보겠습니당!

## 📸 결과물 스크린샷

<img width="620" alt="image" src="https://github.com/Link-MIND/Server/assets/49307946/4c8e12f6-318d-4e69-84fd-a2a2ab2df690">

메인페이지 검색 추가
<img width="633" alt="image" src="https://github.com/Link-MIND/Server/assets/49307946/0f29c84a-84dc-4998-86b5-baa4d4778a4d">


## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- category/search?query=어쩌구
