### PR TITLE
[#21] feature: 유저에 프로필이미지 설정, mypage, settings 페이지 구현

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/controller/MainController.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/MainController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.app.toaster.common.dto.ApiResponse;
+import com.app.toaster.service.UserService;
 import com.app.toaster.service.search.SearchService;
 import com.app.toaster.service.toast.ToastService;
 
@@ -18,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/main")
 public class MainController {
 	private final SearchService searchService;
+	private final UserService userService;
 
 	@GetMapping("/search")
 	public ApiResponse searchProducts(@RequestHeader Long userId ,@RequestParam("query") String query){

--- a/linkmind/src/main/java/com/app/toaster/controller/UserController.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/UserController.java
@@ -1,0 +1,50 @@
+package com.app.toaster.controller;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.app.toaster.common.dto.ApiResponse;
+import com.app.toaster.config.UserId;
+import com.app.toaster.controller.request.user.UpdateAllowedPush;
+import com.app.toaster.exception.Success;
+import com.app.toaster.service.UserService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user")
+public class UserController {
+	private final UserService userService;
+
+	@PatchMapping("/notification")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse updateAllowedNotification (@UserId Long userId, @RequestBody @Valid final UpdateAllowedPush requestDto) {
+		Map<String, Boolean> result = new HashMap<String, Boolean>() {
+			{
+				put("isAllowed", userService.allowedPushNotification(userId, requestDto.allowedPush()));
+			}
+		};
+		return ApiResponse.success(Success.UPDATE_PUSH_ALLOWED_SUCCESS, result);
+	}
+
+	@GetMapping("/my-page")
+	public ApiResponse getMyPage(@RequestHeader Long userId){
+		return ApiResponse.success(Success.GET_MYPAGE_SUCCESS,userService.getMyPage(userId));
+	}
+
+	@GetMapping("/settings")
+	public ApiResponse getSettings(@RequestHeader Long userId){
+		return ApiResponse.success(Success.GET_SETTINGS_SUCCESS,userService.getSettings(userId));
+	}
+}

--- a/linkmind/src/main/java/com/app/toaster/controller/request/user/UpdateAllowedPush.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/request/user/UpdateAllowedPush.java
@@ -1,0 +1,4 @@
+package com.app.toaster.controller.request.user;
+
+public record UpdateAllowedPush(Boolean allowedPush) {
+}

--- a/linkmind/src/main/java/com/app/toaster/controller/response/auth/SignInResponseDto.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/response/auth/SignInResponseDto.java
@@ -1,8 +1,8 @@
 package com.app.toaster.controller.response.auth;
 
-public record SignInResponseDto(Long userId, String accessToken, String refreshToken, String fcmToken, Boolean isRegistered,Boolean FcmIsAllowed) {
+public record SignInResponseDto(Long userId, String accessToken, String refreshToken, String fcmToken, Boolean isRegistered,Boolean FcmIsAllowed, String profile) {
 	public static SignInResponseDto of(Long userId, String accessToken, String refreshToken, String fcmToken,
-		Boolean isRegistered, Boolean fcmIsAllowed){
-		return new SignInResponseDto(userId,accessToken, refreshToken,fcmToken,isRegistered,fcmIsAllowed);
+		Boolean isRegistered, Boolean fcmIsAllowed, String profile){
+		return new SignInResponseDto(userId,accessToken, refreshToken,fcmToken,isRegistered,fcmIsAllowed,profile);
 	}
 }

--- a/linkmind/src/main/java/com/app/toaster/controller/response/user/MyPageResponse.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/response/user/MyPageResponse.java
@@ -1,0 +1,7 @@
+package com.app.toaster.controller.response.user;
+
+public record MyPageResponse(String nickname, String profile, Long allReadToast, Long thisWeekendRead, Long thisWeekendSaved ) {
+	public static MyPageResponse of(String nickname, String profile, Long allReadToast, Long thisWeekendRead, Long thisWeekendSaved ){
+		return new MyPageResponse(nickname, profile, allReadToast, thisWeekendRead, thisWeekendSaved);
+	}
+}

--- a/linkmind/src/main/java/com/app/toaster/controller/response/user/SettingResponse.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/response/user/SettingResponse.java
@@ -1,0 +1,7 @@
+package com.app.toaster.controller.response.user;
+
+public record SettingResponse(String ninkname, Boolean fcmIsAllowed) {
+	public static SettingResponse of(String nickname, Boolean fcmIsAllowed){
+		return new SettingResponse(nickname,fcmIsAllowed);
+	}
+}

--- a/linkmind/src/main/java/com/app/toaster/domain/User.java
+++ b/linkmind/src/main/java/com/app/toaster/domain/User.java
@@ -42,6 +42,9 @@ public class User {
 	@Column(nullable = true)
 	private Boolean fcmIsAllowed = true;
 
+	@Column(nullable = true)
+	private String profile;
+
 	@Builder
 	public User(String nickname, String socialId, SocialType socialType) {
 		this.nickname = nickname;
@@ -66,5 +69,9 @@ public class User {
 			return this.fcmToken;
 		}
 		return null;
+	}
+
+	public void updateProfile(String profile){
+		this.profile = profile;
 	}
 }

--- a/linkmind/src/main/java/com/app/toaster/exception/Success.java
+++ b/linkmind/src/main/java/com/app/toaster/exception/Success.java
@@ -19,6 +19,8 @@ public enum Success {
 	 * 200 OK
 	 */
 	GET_MAIN_SUCCESS(HttpStatus.OK, "메인 페이지 조회 성공"),
+	GET_MYPAGE_SUCCESS(HttpStatus.OK, "마이 페이지 조회 성공"),
+	GET_SETTINGS_SUCCESS(HttpStatus.OK, "설정 페이지 조회 성공"),
 
   	LOGIN_SUCCESS(HttpStatus.OK, "로그인 성공"),
 	RE_ISSUE_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급 성공"),
@@ -27,7 +29,7 @@ public enum Success {
 	DELETE_TOAST_SUCCESS(HttpStatus.OK, "토스트 삭제 성공"),
 	SEARCH_SUCCESS(HttpStatus.OK, "검색 성공"),
 	PARSING_OG_SUCCESS(HttpStatus.OK, "og 데이터 파싱 결과입니다. 크롤링을 막은 페이지는 기본이미지가 나옵니다."),
-
+	UPDATE_PUSH_ALLOWED_SUCCESS(HttpStatus.OK, "푸시알림 수정 성공"),
 
 	UPDATE_ISREAD_SUCCESS(HttpStatus.OK, "열람여부 수정 완료"),
 

--- a/linkmind/src/main/java/com/app/toaster/exception/model/net/CustomJavaNetException.java
+++ b/linkmind/src/main/java/com/app/toaster/exception/model/net/CustomJavaNetException.java
@@ -1,0 +1,22 @@
+package com.app.toaster.exception.model.net;
+
+import java.io.IOException;
+
+import com.app.toaster.exception.Error;
+
+import lombok.Getter;
+
+@Getter
+public class CustomJavaNetException extends IOException {
+	private final Error error;
+
+	public CustomJavaNetException(Error error, String message) {
+		super(message);
+		this.error = error;
+	}
+
+	public int getHttpStatus() {
+		return error.getErrorCode();
+	}
+
+}

--- a/linkmind/src/main/java/com/app/toaster/exception/model/net/UnknownHostException.java
+++ b/linkmind/src/main/java/com/app/toaster/exception/model/net/UnknownHostException.java
@@ -1,0 +1,11 @@
+package com.app.toaster.exception.model.net;
+
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.CustomException;
+
+public class UnknownHostException extends CustomJavaNetException {
+	public UnknownHostException(Error error, String message) {
+		super(error, message);
+	}
+
+}

--- a/linkmind/src/main/java/com/app/toaster/infrastructure/ToastRepository.java
+++ b/linkmind/src/main/java/com/app/toaster/infrastructure/ToastRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import com.app.toaster.domain.Category;
 import com.app.toaster.domain.Toast;
+import com.app.toaster.domain.User;
 
 public interface ToastRepository extends JpaRepository<Toast, Long> {
 
@@ -15,4 +16,10 @@ public interface ToastRepository extends JpaRepository<Toast, Long> {
 		"t.title LIKE CONCAT('%',:query, '%')"
 	)
 	List<Toast> searchToastsByQuery(Long userId, String query);
+
+	Long countAllByUser(User user);
+
+	Long countALLByUserAndIsReadTrue(User user);
+
+	Long countAllByUserAndIsReadFalse(User user);
 }

--- a/linkmind/src/main/java/com/app/toaster/service/UserService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/UserService.java
@@ -1,0 +1,60 @@
+package com.app.toaster.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.app.toaster.controller.response.user.MyPageResponse;
+import com.app.toaster.controller.response.user.SettingResponse;
+import com.app.toaster.domain.User;
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.BadRequestException;
+import com.app.toaster.exception.model.NotFoundException;
+import com.app.toaster.infrastructure.ToastRepository;
+import com.app.toaster.infrastructure.UserRepository;
+import com.app.toaster.service.toast.ToastService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+	private final UserRepository userRepository;
+	private final ToastRepository toastRepository;
+	public MyPageResponse getMyPage(Long userId){
+		User user = userRepository.findByUserId(userId)
+			.orElseThrow(()-> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
+		return MyPageResponse.of(
+			user.getNickname(),
+			user.getProfile(),
+			toastRepository.countAllByUser(user),
+			toastRepository.countALLByUserAndIsReadTrue(user),
+			toastRepository.countAllByUserAndIsReadFalse(user)
+		);
+	}
+	//푸시알림 동의 여부 수정 api
+	@Transactional
+	public Boolean allowedPushNotification(Long userId, Boolean fcmIsAllowed) {
+		User user = userRepository.findByUserId(userId)
+			.orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION,
+				Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
+		if (fcmIsAllowed == user.getFcmIsAllowed()) {   //같은 경우면 에러가 날 수 있으니 에러 띄움.
+			throw new BadRequestException(Error.BAD_REQUEST_VALIDATION,
+				Error.BAD_REQUEST_VALIDATION.getMessage());
+		}
+		user.updateFcmIsAllowed(fcmIsAllowed);
+		return fcmIsAllowed;
+	}
+
+	public SettingResponse getSettings(Long userId){
+		User user = userRepository.findByUserId(userId)
+			.orElseThrow(()-> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
+		return SettingResponse.of(
+			user.getNickname(),
+			user.getFcmIsAllowed()
+		);
+	}
+
+
+}

--- a/linkmind/src/main/java/com/app/toaster/service/auth/apple/AppleSignInService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/apple/AppleSignInService.java
@@ -10,6 +10,8 @@ import org.springframework.web.client.RestClient;
 import com.app.toaster.service.auth.apple.response.ApplePublicKeys;
 import com.app.toaster.service.auth.apple.verify.AppleJwtParser;
 import com.app.toaster.service.auth.apple.verify.PublicKeyGenerator;
+import com.app.toaster.service.auth.kakao.LoginResult;
+import com.mysql.cj.log.Log;
 
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +24,7 @@ public class AppleSignInService {
 	private static AppleJwtParser appleJwtParser;
 	private static PublicKeyGenerator publicKeyGenerator;
 
-	public String getAppleId(String identityToken) {
+	public LoginResult getAppleId(String identityToken) {
 		Map<String, String> headers = appleJwtParser.parseHeaders(identityToken);
 
 		ResponseEntity<ApplePublicKeys> result = restClient.get()
@@ -33,6 +35,6 @@ public class AppleSignInService {
 		PublicKey publicKey = publicKeyGenerator.generatePublicKey(headers, result.getBody());
 
 		Claims claims = appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
-		return claims.getSubject();
+		return LoginResult.of(claims.getSubject(),null);
 	}
 }

--- a/linkmind/src/main/java/com/app/toaster/service/auth/kakao/KakaoAccount.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/kakao/KakaoAccount.java
@@ -1,0 +1,4 @@
+package com.app.toaster.service.auth.kakao;
+
+public record KakaoAccount(KakaoUserProfile profile) {
+}

--- a/linkmind/src/main/java/com/app/toaster/service/auth/kakao/KakaoSignInService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/kakao/KakaoSignInService.java
@@ -1,5 +1,6 @@
 package com.app.toaster.service.auth.kakao;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -20,7 +21,7 @@ public class KakaoSignInService {
 	@Value("${jwt.KAKAO_URL}")
 	private String KAKAO_URL;
 
-	public String getKaKaoId(String accessToken) {
+	public LoginResult getKaKaoId(String accessToken) {
 		RestTemplate restTemplate = new RestTemplate();
 		HttpHeaders headers = new HttpHeaders();
 		headers.add("Authorization","Bearer "+ accessToken);
@@ -28,6 +29,8 @@ public class KakaoSignInService {
 		ResponseEntity<Object> responseData;
 		responseData = restTemplate.postForEntity(KAKAO_URL,httpEntity,Object.class);
 		ObjectMapper objectMapper = new ObjectMapper();
-		return objectMapper.convertValue(responseData.getBody(), Map.class).get("id").toString(); //소셜 id만 가져오는듯.
+		HashMap profileResponse = (HashMap)objectMapper.convertValue( responseData.getBody(),Map.class).get("properties");
+		System.out.println(profileResponse.get("profile_image").toString());
+		return LoginResult.of(objectMapper.convertValue(responseData.getBody(), Map.class).get("id").toString(), profileResponse.get("profile_image").toString()); //소셜 id만 가져오는듯.
 	}
 }

--- a/linkmind/src/main/java/com/app/toaster/service/auth/kakao/KakaoUserProfile.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/kakao/KakaoUserProfile.java
@@ -1,0 +1,4 @@
+package com.app.toaster.service.auth.kakao;
+
+public record KakaoUserProfile(String nickname, String profileImageUrl) {
+}

--- a/linkmind/src/main/java/com/app/toaster/service/auth/kakao/KakaoUserResponse.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/kakao/KakaoUserResponse.java
@@ -1,0 +1,7 @@
+package com.app.toaster.service.auth.kakao;
+
+public record KakaoUserResponse(KakaoAccount kakaoAccount) {
+	public static KakaoUserResponse of(KakaoAccount kakaoAccount){
+		return new KakaoUserResponse(kakaoAccount);
+	}
+}

--- a/linkmind/src/main/java/com/app/toaster/service/auth/kakao/LoginResult.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/kakao/LoginResult.java
@@ -1,0 +1,7 @@
+package com.app.toaster.service.auth.kakao;
+
+public record LoginResult(String id, String profile) {
+	public static LoginResult of(String id, String profile){
+		return new LoginResult(id,profile);
+	}
+}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #21 

## 📋 구현 기능 명세
- [x] 유저 엔티티에 프로필 이미지 추가
- [x] 카카오에서 유저 프로필 이미지 받아오기 추가에 따른 response 구조 변경
- [x] 마이페이지 get 구현
- [x] 설정페이지 get 구현   

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
프로필 이미지를 가져오는게 계속 null이 가져와져서 확인 해보니 허용이 안되어있었습니당! 일단 허용 안된 경우에 null값이면 기본이미지로 세팅하도록 설정했습니다!

- 어떤 부분에 리뷰어가 집중해야 하는지
빠뜨린 부분은 없는지..!

- 개발하면서 어떤 점이 궁금했는지


## 📸 결과물 스크린샷
```java
{
    "code": 200,
    "message": "마이 페이지 조회 성공",
    "data": {
        "nickname": "토스터3277651744",
        "profile": "http://k.kakaocdn.net/dn/b1xTBE/btsyuhhLq0W/BDYXmvQlzz51PY2NnlbUVK/img_640x640.jpg",
        "allReadToast": 0,
        "thisWeekendRead": 0,
        "thisWeekendSaved": 0
    }
}
```

```java
{
    "code": 200,
    "message": "로그인 성공",
    "data": {
        "userId": 7,
        "accessToken": "어쩌구",
        "refreshToken": "저쩌구",
        "fcmToken": null,
        "isRegistered": true,
        "FcmIsAllowed": true,
        "profile": "http://k.kakaocdn.net/어쩌구/img_640x640.jpg"
    }
}
```

```java
{
    "code": 200,
    "message": "설정 페이지 조회 성공",
    "data": {
        "ninkname": "토스터3277651744",
        "fcmIsAllowed": true
    }
}
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/auth
- baseurl/user/my-page
- baseurl/user/settings
