### PR TITLE
Fix/#35

### DIFF
--- a/linkmind/build.gradle
+++ b/linkmind/build.gradle
@@ -64,6 +64,12 @@ dependencies {
 	// JSoup
 	implementation 'org.jsoup:jsoup:1.15.3'
 
+	// slack
+	implementation 'com.slack.api:slack-api-client:1.28.0'
+	implementation 'com.google.code.gson:gson:2.10.1'
+	implementation 'com.slack.api:slack-app-backend:1.28.0'
+	implementation 'com.slack.api:slack-api-model:1.28.0'
+
 }
 
 tasks.named('test') {

--- a/linkmind/build.gradle
+++ b/linkmind/build.gradle
@@ -8,6 +8,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.2.0'
 	id 'io.spring.dependency-management' version '1.1.4'
+	id "io.sentry.jvm.gradle" version "4.1.1"
 }
 
 group = 'com.app'
@@ -74,4 +75,15 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+sentry {
+	// Generates a JVM (Java, Kotlin, etc.) source bundle and uploads your source code to Sentry.
+	// This enables source context, allowing you to see your source
+	// code as part of your stack traces in Sentry.
+	includeSourceContext = true
+
+	org = "linkmind"
+	projectName = "java-spring-boot"
+	authToken = System.getenv("SENTRY_AUTH_TOKEN")
 }

--- a/linkmind/src/main/java/com/app/toaster/common/advice/ControllerExceptionAdvice.java
+++ b/linkmind/src/main/java/com/app/toaster/common/advice/ControllerExceptionAdvice.java
@@ -18,6 +18,7 @@ import com.app.toaster.exception.Error;
 import com.app.toaster.exception.model.CustomException;
 import com.app.toaster.external.client.slack.SlackApi;
 
+import io.sentry.Sentry;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintDefinitionException;
 import lombok.NoArgsConstructor;
@@ -34,6 +35,7 @@ public class ControllerExceptionAdvice {
 	 */
 	@ExceptionHandler(CustomException.class)
 	protected ResponseEntity<ApiResponse> handleCustomException(CustomException e) {
+		Sentry.captureException(e);
 		return ResponseEntity.status(e.getHttpStatus())
 			.body(ApiResponse.error(e.getError(), e.getMessage()));
 	}
@@ -46,11 +48,13 @@ public class ControllerExceptionAdvice {
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	protected ResponseEntity<ApiResponse> handleConstraintDefinitionException(final MethodArgumentNotValidException e) {
 		FieldError fieldError = e.getBindingResult().getFieldError();
+		Sentry.captureException(e);
 		return ResponseEntity.status(e.getStatusCode())
 			.body(ApiResponse.error(Error.BAD_REQUEST_VALIDATION, fieldError.getDefaultMessage()));
 	}
 	@ExceptionHandler(MalformedURLException.class)
 	protected ApiResponse handleConstraintDefinitionException(final MalformedURLException e) {
+		Sentry.captureException(e);
 		return ApiResponse.error(Error.MALFORMED_URL_EXEPTION, Error.MALFORMED_URL_EXEPTION.getMessage());
 	}
 
@@ -62,6 +66,7 @@ public class ControllerExceptionAdvice {
 	protected ApiResponse<Object> handleException(final Exception error, final HttpServletRequest request) throws
 		IOException {
 		slackApi.sendAlert(error, request);
+		Sentry.captureException(error);
 		return ApiResponse.error(Error.INTERNAL_SERVER_ERROR);
 	}
 

--- a/linkmind/src/main/java/com/app/toaster/controller/AuthController.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.app.toaster.controller;
 
+import java.io.IOException;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,7 +33,7 @@ public class AuthController {
 	public ApiResponse<SignInResponseDto> signIn(
 		@RequestHeader("Authorization") String socialAccessToken,
 		@RequestBody SignInRequestDto requestDto
-	) {
+	) throws IOException {
 		return ApiResponse.success(Success.LOGIN_SUCCESS, authService.signIn(socialAccessToken, requestDto));
 	}
 

--- a/linkmind/src/main/java/com/app/toaster/external/client/slack/SlackApi.java
+++ b/linkmind/src/main/java/com/app/toaster/external/client/slack/SlackApi.java
@@ -1,0 +1,130 @@
+package com.app.toaster.external.client.slack;
+
+import static com.slack.api.model.block.composition.BlockCompositions.*;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.app.toaster.exception.Success;
+import com.app.toaster.infrastructure.UserRepository;
+import com.slack.api.Slack;
+import com.slack.api.model.block.Blocks;
+import com.slack.api.model.block.LayoutBlock;
+import com.slack.api.model.block.composition.BlockCompositions;
+import com.slack.api.webhook.WebhookPayloads;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SlackApi {
+
+	@Value("${slack.webhook.error}")
+	private String errorUrl;
+	@Value("${slack.webhook.success}")
+	private String successUrl;
+	private final static String NEW_LINE = "\n";
+	private final static String DOUBLE_NEW_LINE = "\n\n";
+
+	private final UserRepository userRepository;
+
+	private StringBuilder sb = new StringBuilder();
+
+	public void sendAlert(Exception error, HttpServletRequest request) throws IOException {
+
+		List<LayoutBlock> layoutBlocks = generateLayoutBlock(error, request);
+
+		Slack.getInstance().send(errorUrl, WebhookPayloads
+			.payload(p ->
+				p.username("Exception is detected 🚨")
+					.iconUrl("https://yt3.googleusercontent.com/ytc/AGIKgqMVUzRrhoo1gDQcqvPo0PxaJz7e0gqDXT0D78R5VQ=s900-c-k-c0x00ffffff-no-rj")
+					.blocks(layoutBlocks)));
+	}
+
+	private List<LayoutBlock> generateLayoutBlock(Exception error, HttpServletRequest request) {
+		return Blocks.asBlocks(
+			getHeader("서버 측 오류로 예상되는 예외 상황이 발생하였습니다."),
+			Blocks.divider(),
+			getSection(generateErrorMessage(error)),
+			Blocks.divider(),
+			getSection(generateErrorPointMessage(request)),
+			Blocks.divider(),
+			getSection("<https://github.com/team-winey/Winey-Server/issues|이슈 생성하러 가기>")
+		);
+	}
+
+	private List<LayoutBlock> generateSuccessBlock(Success success) {
+		return Blocks.asBlocks(
+			getHeader("😍회원가입 이벤트가 발생했습니다."),
+			Blocks.divider(),
+			getSection(generateSuccessMessage(success)),
+			Blocks.divider(),
+			getSection(generateSignUpMessage()),
+			Blocks.divider()
+		);
+	}
+
+	private String generateErrorMessage(Exception error) {
+		sb.setLength(0);
+		sb.append("*[🔥 Exception]*" + NEW_LINE + error.toString() + DOUBLE_NEW_LINE);
+		sb.append("*[📩 From]*" + NEW_LINE + readRootStackTrace(error) + DOUBLE_NEW_LINE);
+
+		return sb.toString();
+	}
+
+	private String generateSuccessMessage(Success success) {
+		sb.setLength(0);
+		sb.append("*[🔥 축하합니다!]*" + NEW_LINE + "토스트 굽는 소리가 들려요~!" + DOUBLE_NEW_LINE);
+
+		return sb.toString();
+	}
+
+	private String generateErrorPointMessage(HttpServletRequest request) {
+		sb.setLength(0);
+		sb.append("*[🧾세부정보]*" + NEW_LINE);
+		sb.append("Request URL : " + request.getRequestURL().toString() + NEW_LINE);
+		sb.append("Request Method : " + request.getMethod() + NEW_LINE);
+		sb.append("Request Time : " + new Date() + NEW_LINE);
+
+		return sb.toString();
+	}
+	private String generateSignUpMessage() {
+		sb.setLength(0);
+		sb.append("*[🧾유저 가입 정보]*" + NEW_LINE);
+		sb.append("토스터의 " + userRepository.count() + "번째 유저가 생성되었습니다!!❤️");
+		return sb.toString();
+	}
+
+	private String readRootStackTrace(Exception error) {
+		return error.getStackTrace()[0].toString();
+	}
+
+	private LayoutBlock getHeader(String text) {
+		return Blocks.header(h -> h.text(
+			plainText(pt -> pt.emoji(true)
+				.text(text))));
+	}
+
+	private LayoutBlock getSection(String message) {
+		return Blocks.section(s ->
+			s.text(BlockCompositions.markdownText(message)));
+	}
+
+	public void sendSuccess(Success success) throws IOException {
+
+		List<LayoutBlock> layoutBlocks = generateSuccessBlock(success);
+
+		Slack.getInstance().send(successUrl, WebhookPayloads
+			.payload(p ->
+				p.username("Exception is detected 🚨")
+					.iconUrl("https://yt3.googleusercontent.com/ytc/AGIKgqMVUzRrhoo1gDQcqvPo0PxaJz7e0gqDXT0D78R5VQ=s900-c-k-c0x00ffffff-no-rj")
+					.blocks(layoutBlocks)));
+	}
+}

--- a/linkmind/src/main/java/com/app/toaster/service/auth/kakao/KakaoSignInService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/kakao/KakaoSignInService.java
@@ -30,7 +30,6 @@ public class KakaoSignInService {
 		responseData = restTemplate.postForEntity(KAKAO_URL,httpEntity,Object.class);
 		ObjectMapper objectMapper = new ObjectMapper();
 		HashMap profileResponse = (HashMap)objectMapper.convertValue( responseData.getBody(),Map.class).get("properties");
-		System.out.println(profileResponse.get("profile_image").toString());
-		return LoginResult.of(objectMapper.convertValue(responseData.getBody(), Map.class).get("id").toString(), profileResponse.get("profile_image").toString()); //소셜 id만 가져오는듯.
+		return LoginResult.of(objectMapper.convertValue(responseData.getBody(), Map.class).get("id").toString(), profileResponse==null?null:profileResponse.get("profile_image").toString()); //프로필 이미지 허용 x시 null로 넘기기.
 	}
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #35 

## 📋 구현 기능 명세
- [x] 회원 가입 시 NPE 해결

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
프로필 이미지 허용을 안하면 response에서 null 값이 오는 것을 해결했습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지
또 빠뜨린 부분이 있는지 확인하면 좋을 것 같습니다.

- 개발하면서 어떤 점이 궁금했는지
sentry 엄청 편한 것 같습니다.
## 📸 결과물 스크린샷
```java
{
    "code": 200,
    "message": "로그인 성공",
    "data": {
        "userId": 3,
        "accessToken": "저쩌구",
        "refreshToken": "어쩌구",
        "fcmToken": null,
        "isRegistered": true,
        "FcmIsAllowed": true,
        "profile": "기본이미지"
    }
}
```
<img width="579" alt="image" src="https://github.com/Link-MIND/TOASTER-Server/assets/49307946/8342b1a1-7f0f-4348-a99b-429e2d458b80">


## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/auth
