### PR TITLE
[Feature/#45] 타이머 알람여부 수정 API

### DIFF
--- a/linkmind/build.gradle
+++ b/linkmind/build.gradle
@@ -8,7 +8,6 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.2.0'
 	id 'io.spring.dependency-management' version '1.1.4'
-	id "io.sentry.jvm.gradle" version "4.1.1"
 }
 
 group = 'com.app'
@@ -71,19 +70,10 @@ dependencies {
 	implementation 'com.slack.api:slack-app-backend:1.28.0'
 	implementation 'com.slack.api:slack-api-model:1.28.0'
 
+	implementation 'io.sentry:sentry-spring-boot-starter:5.7.0'
+
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
-}
-
-sentry {
-	// Generates a JVM (Java, Kotlin, etc.) source bundle and uploads your source code to Sentry.
-	// This enables source context, allowing you to see your source
-	// code as part of your stack traces in Sentry.
-	includeSourceContext = true
-
-	org = "linkmind"
-	projectName = "java-spring-boot"
-	authToken = System.getenv("SENTRY_TOKEN")
 }

--- a/linkmind/src/main/java/com/app/toaster/controller/TimerController.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/TimerController.java
@@ -82,4 +82,13 @@ public class TimerController {
             @UserId Long userId) throws IOException {
         return ApiResponse.success(Success.GET_TIMER_PAGE_SUCCESS, timerService.getTimerPage(userId));
     }
+
+    @PatchMapping("/alarm/{timerId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse changeAlarm(
+            @UserId Long userId,
+            @PathVariable Long timerId) {
+        timerService.changeAlarm(userId, timerId);
+        return ApiResponse.success(Success.CHANGE_TIMER_ALARM_SUCCESS);
+    }
 }

--- a/linkmind/src/main/java/com/app/toaster/domain/Reminder.java
+++ b/linkmind/src/main/java/com/app/toaster/domain/Reminder.java
@@ -57,4 +57,8 @@ public class Reminder extends BaseTimeEntity {
 	public void updateComment(String comment){
 		this.comment = comment;
 	}
+
+	public void changeAlarm(){
+		this.isAlarm = !isAlarm;
+	}
 }

--- a/linkmind/src/main/java/com/app/toaster/exception/Success.java
+++ b/linkmind/src/main/java/com/app/toaster/exception/Success.java
@@ -43,6 +43,7 @@ public enum Success {
 	UPDATE_CATEGORY_TITLE_SUCCESS(HttpStatus.OK, "카테고리 수정 완료"),
 	UPDATE_TIMER_DATETIME_SUCCESS(HttpStatus.OK, "타이머 시간/날짜 수정 완료"),
 	UPDATE_TIMER_COMMENT_SUCCESS(HttpStatus.OK, "타이머 코멘트 수정 완료"),
+	CHANGE_TIMER_ALARM_SUCCESS(HttpStatus.OK, "타이머 알람여부 수정 완료"),
 
 
 	/**

--- a/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
@@ -122,6 +122,20 @@ public class TimerService {
         timerRepository.delete(reminder);
     }
 
+    @Transactional
+    public void changeAlarm(Long userId, Long timerId){
+        User presentUser = findUser(userId);
+
+        Reminder reminder = timerRepository.findById(timerId)
+                .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_TIMER, Error.NOT_FOUND_TIMER.getMessage()));
+
+        if (!presentUser.equals(reminder.getUser())){
+            throw new UnauthorizedException(Error.INVALID_USER_ACCESS, Error.INVALID_USER_ACCESS.getMessage());
+        }
+
+        reminder.changeAlarm();
+    }
+
     public GetTimerPageResponseDto getTimerPage(Long userId) throws IOException {
         User presentUser = findUser(userId);
         ArrayList<Reminder> reminders = timerRepository.findAllByUser(presentUser);


### PR DESCRIPTION
## 🚩 관련 이슈
- close #45 

## 📋 구현 기능 명세
- [x] 타이머 알람여부 수정 API

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지


- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
<img width="547" alt="스크린샷 2024-01-11 오전 3 18 42" src="https://github.com/Link-MIND/TOASTER-Server/assets/92644651/8540ef84-2856-47b4-9db2-937ba847d5b7">


## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/timer/alarm/{timerId}
