### PR TITLE
[Feature#48] 타이머 페이지 조회 API 수정

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -25,6 +25,12 @@ jobs:
           echo "${{ secrets.APPLICATION }}" > ./application-dev.yaml
       working-directory: ${{ env.working-directory }}
 
+    - name: toaster-firebase-admin-sdk.json 생성
+      run: |
+          cd src/main/resources
+          echo "${{ secrets.TOASTER_FIREBASE_ADMIN_SDK }}" > ./toaster-firebase-admin-sdk.json
+      working-directory: ${{ env.working-directory }}
+
     - name: 빌드
       run: |
           chmod +x gradlew

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,11 @@ jobs:
           echo "${{ secrets.APPLICATION }}" > ./application.yaml
       working-directory: ${{ env.working-directory }}
 
+    - name: toaster-firebase-admin-sdk.json 생성
+      run: |
+          cd src/main/resources
+          echo "${{ secrets.TOASTER_FIREBASE_ADMIN_SDK }}" > ./toaster-firebase-admin-sdk.json
+      working-directory: ${{ env.working-directory }}
     - name: 빌드
       run: |
           chmod +x gradlew

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: toaster-firebase-admin-sdk.json 생성
       run: |
-          cd ${{ env.working-directory }}/src/main/resources
+          cd src/main/resources
           echo "${{ secrets.TOASTER_FIREBASE_ADMIN_SDK }}" > ./toaster-firebase-admin-sdk.json
       working-directory: ${{ env.working-directory }}
       

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: toaster-firebase-admin-sdk.json 생성
       run: |
-          cd src/main/resources
+          cd ${{ env.working-directory }}/src/main/resources
           echo "${{ secrets.TOASTER_FIREBASE_ADMIN_SDK }}" > ./toaster-firebase-admin-sdk.json
       working-directory: ${{ env.working-directory }}
       

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,7 @@ jobs:
           cd src/main/resources
           echo "${{ secrets.TOASTER_FIREBASE_ADMIN_SDK }}" > ./toaster-firebase-admin-sdk.json
       working-directory: ${{ env.working-directory }}
+      
     - name: 빌드
       run: |
           chmod +x gradlew

--- a/linkmind/build.gradle
+++ b/linkmind/build.gradle
@@ -8,7 +8,6 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.2.0'
 	id 'io.spring.dependency-management' version '1.1.4'
-	id "io.sentry.jvm.gradle" version "4.1.1"
 }
 
 group = 'com.app'
@@ -39,7 +38,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-	implementation 'io.sentry:sentry-spring-boot-starter:5.1.0'
+	implementation 'io.sentry:sentry-spring-boot-starter:5.7.0'
 	//JWT
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'

--- a/linkmind/build.gradle
+++ b/linkmind/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	implementation 'io.sentry:sentry-spring-boot-starter:5.1.0'
 	//JWT
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
@@ -75,15 +76,4 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
-}
-
-sentry {
-	// Generates a JVM (Java, Kotlin, etc.) source bundle and uploads your source code to Sentry.
-	// This enables source context, allowing you to see your source
-	// code as part of your stack traces in Sentry.
-	includeSourceContext = true
-
-	org = "linkmind"
-	projectName = "java-spring-boot"
-	authToken = System.getenv("SENTRY_TOKEN")
 }

--- a/linkmind/src/main/java/com/app/toaster/controller/response/timer/WaitingTimerDto.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/response/timer/WaitingTimerDto.java
@@ -6,8 +6,8 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-public record WaitingTimerDto(Long timerId, String remindTime, String remindDates, Boolean isAlarm, LocalDateTime updateAt) {
+public record WaitingTimerDto(Long timerId, String remindTime, String remindDates, Boolean isAlarm, LocalDateTime updateAt, String comment) {
     public static WaitingTimerDto of(Reminder timer, String remindTime, String remindDates) {
-        return new WaitingTimerDto(timer.getId(), remindTime, remindDates, timer.getIsAlarm(), timer.getUpdateAt());
+        return new WaitingTimerDto(timer.getId(), remindTime, remindDates, timer.getIsAlarm(), timer.getUpdateAt(), timer.getComment());
     }
 }

--- a/linkmind/src/main/java/com/app/toaster/controller/response/timer/WaitingTimerDto.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/response/timer/WaitingTimerDto.java
@@ -6,8 +6,8 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-public record WaitingTimerDto(Long timerId, String remindTime, String remindDates, Boolean isAlarm, LocalDateTime updateAt, String comment) {
+public record WaitingTimerDto(Long timerId, String remindTime, String remindDates, Boolean isAlarm, LocalDateTime updateAt, String comment, Long categoryId) {
     public static WaitingTimerDto of(Reminder timer, String remindTime, String remindDates) {
-        return new WaitingTimerDto(timer.getId(), remindTime, remindDates, timer.getIsAlarm(), timer.getUpdateAt(), timer.getComment());
+        return new WaitingTimerDto(timer.getId(), remindTime, remindDates, timer.getIsAlarm(), timer.getUpdateAt(), timer.getComment(), timer.getCategory().getCategoryId());
     }
 }

--- a/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
@@ -63,7 +63,7 @@ public class TimerService {
                 .remindDates(createTimerRequestDto.remindDates())
                 .remindTime(LocalTime.parse(createTimerRequestDto.remindTime()))
                 .isAlarm(true)
-                .comment(category.getTitle() + " 링크들을 읽기 딱 좋은 시간이에요!")
+                .comment(category.getTitle())
                 .build();
 
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #48 

## 📋 구현 기능 명세
- [x] 타이머 comment -> 그냥 카테고리명으로 변경
- [x] 대기중인 타이머 response에 comment 추가
- [x] 대기중인 타이머 카테고리 id추가

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
타이머 조회 페이지 comment를 전체로 넘겨주면 클라가 처리하기 불편하다하여 카테고리명만 내려주는 것으로 변경하였습니다.
또한 디자인 변경으로 대기중인 타이머에도 comment를 추가하여 클립명을 알려주었습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
```
{
    "code": 200,
    "message": "타이머 페이지 조회 성공",
    "data": {
        "completedTimerList": [],
        "waitingTimerList": [
            {
                "timerId": 12,
                "remindTime": "오후 7시 23분",
                "remindDates": "목",
                "isAlarm": false,
                "updateAt": "2024-01-11T11:10:33",
                "comment": "카테고리 제목",
                "categoryId": 20
            }
        ]
    }
}
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/timer/main
