### PR TITLE
Fix/#65

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/service/auth/AuthService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/AuthService.java
@@ -44,8 +44,8 @@ public class AuthService {
 	private final SlackApi slackApi;
 
 
-	private final Long TOKEN_EXPIRATION_TIME_ACCESS = 1* 60 * 1000L; //1분
-	private final Long TOKEN_EXPIRATION_TIME_REFRESH = 3 * 60 * 1000L; //3분
+	private final Long TOKEN_EXPIRATION_TIME_ACCESS = 60* 60 * 1000L; //1분
+	private final Long TOKEN_EXPIRATION_TIME_REFRESH = 3*60 * 60 * 1000L; //3분
 	@Value("${static-image.root}")
 	private String BASIC_ROOT;
 

--- a/linkmind/src/main/java/com/app/toaster/service/auth/apple/AppleSignInService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/apple/AppleSignInService.java
@@ -15,14 +15,16 @@ import com.mysql.cj.log.Log;
 
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AppleSignInService {
 	private static final String APPLE_URI = "https://appleid.apple.com/auth";
 	private static final RestClient restClient = RestClient.create(APPLE_URI);
-	private static AppleJwtParser appleJwtParser;
-	private static PublicKeyGenerator publicKeyGenerator;
+	private final AppleJwtParser appleJwtParser;
+	private final PublicKeyGenerator publicKeyGenerator;
 
 	public LoginResult getAppleId(String identityToken) {
 		Map<String, String> headers = appleJwtParser.parseHeaders(identityToken);
@@ -31,9 +33,7 @@ public class AppleSignInService {
 			.uri("/keys")
 			.retrieve()
 			.toEntity(ApplePublicKeys.class);
-
 		PublicKey publicKey = publicKeyGenerator.generatePublicKey(headers, result.getBody());
-
 		Claims claims = appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
 		return LoginResult.of(claims.getSubject(),null);
 	}

--- a/linkmind/src/main/java/com/app/toaster/service/auth/apple/response/ApplePublicKeys.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/apple/response/ApplePublicKeys.java
@@ -5,6 +5,8 @@ import java.util.List;
 import com.app.toaster.exception.Error;
 import com.app.toaster.exception.model.CustomException;
 
+import lombok.extern.slf4j.Slf4j;
+
 public record ApplePublicKeys(List<ApplePublicKey> keys) {
 
 	public ApplePublicKey getMatchesKey(String alg, String kid) {

--- a/linkmind/src/main/java/com/app/toaster/service/auth/apple/verify/AppleJwtParser.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/apple/verify/AppleJwtParser.java
@@ -16,8 +16,10 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
+@Slf4j
 public class AppleJwtParser {
 
 	private static final String IDENTITY_TOKEN_VALUE_DELIMITER = "\\.";

--- a/linkmind/src/main/java/com/app/toaster/service/auth/apple/verify/PublicKeyGenerator.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/apple/verify/PublicKeyGenerator.java
@@ -16,6 +16,8 @@ import com.app.toaster.exception.model.CustomException;
 import com.app.toaster.service.auth.apple.response.ApplePublicKey;
 import com.app.toaster.service.auth.apple.response.ApplePublicKeys;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Component
 public class PublicKeyGenerator {
 
@@ -26,13 +28,12 @@ public class PublicKeyGenerator {
 	public PublicKey generatePublicKey(Map<String, String> headers, ApplePublicKeys applePublicKeys) {
 		ApplePublicKey applePublicKey =
 			applePublicKeys.getMatchesKey(headers.get(SIGN_ALGORITHM_HEADER_KEY), headers.get(KEY_ID_HEADER_KEY));
-
 		return generatePublicKeyWithApplePublicKey(applePublicKey);
 	}
 
 	private PublicKey generatePublicKeyWithApplePublicKey(ApplePublicKey publicKey) {
-		byte[] nBytes = Base64.getDecoder().decode(publicKey.n());
-		byte[] eBytes = Base64.getDecoder().decode(publicKey.e());
+		byte[] nBytes = Base64.getUrlDecoder().decode(publicKey.n());
+		byte[] eBytes = Base64.getUrlDecoder().decode(publicKey.e());
 
 		BigInteger n = new BigInteger(POSITIVE_SIGN_NUMBER, nBytes);
 		BigInteger e = new BigInteger(POSITIVE_SIGN_NUMBER, eBytes);


### PR DESCRIPTION
## 🚩 관련 이슈
- close #65 

## 📋 구현 기능 명세
- [x] base 64관련 로직 수정

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
base64에서 utils 라이브러리의 safeUrl이 deprecated되어서 코드를 수정했는데 토큰 실험을 해보니 다음과 같은 이슈가 있었습니다!ㅠㅠ
```java
java.lang.IllegalArgumentException: Illegal base64 character 5f
```
이 에러의 해결법은 '+'랑 '-'를 replace해서 replace('/', '_') 이렇게 바꾸려고 했는데 이방법이 안돼서 
getDecoder -> getUrlDecoder로 메소드를 변경했더니 성공해서 푸시합니다!
- 어떤 부분에 리뷰어가 집중해야 하는지
더 좋은 방법 있는지 고민해보면 좋을 것 같습니다.

- 개발하면서 어떤 점이 궁금했는지
safeUrlDecoder를 대체하는 더 좋은 메소드가 있는지.

## 📸 결과물 스크린샷
```java
결과 예시 사진 첨부
```

## 🛠️ 테스트
- [x] id토큰으로 테스트 완료

## 🚀 API Endpoint
- baseurl/auth
