### PR TITLE
[#71] fix: 타이머 포맷 한국시간으로 설정

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
@@ -209,7 +209,7 @@ public class TimerService {
     // 인덱스로 요일 알아내기
     private String mapIndexToDayString(int index) {
         DayOfWeek dayOfWeek = DayOfWeek.of(index);
-        String dayName = dayOfWeek.getDisplayName(java.time.format.TextStyle.FULL, Locale.getDefault());
+        String dayName = dayOfWeek.getDisplayName(java.time.format.TextStyle.FULL, Locale.KOREAN);
 
         return dayName.substring(0, 1);
     }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #71 

## 📋 구현 기능 명세
- [x] 타이머 포맷 한국시간으로 설정

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
포맷 시간을 default로 했더니 미국시간으로 포맷되는경우가 있어서 한국시간으로 고정 설정했습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
<img width="555" alt="스크린샷 2024-01-14 오후 9 07 06" src="https://github.com/Link-MIND/TOASTER-Server/assets/92644651/19eb595f-c521-4387-bff5-8135584b002a">

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/timer/main
