### PR TITLE
[#71] fix: 타이머 시간 한국시간으로 변경

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/ToasterApplication.java
+++ b/linkmind/src/main/java/com/app/toaster/ToasterApplication.java
@@ -4,6 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import javax.annotation.PostConstruct;
+import java.util.TimeZone;
+
 @SpringBootApplication
 @EnableJpaAuditing
 public class ToasterApplication {
@@ -12,4 +15,8 @@ public class ToasterApplication {
 		SpringApplication.run(ToasterApplication.class, args);
 	}
 
+	@PostConstruct
+	public void init() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 }

--- a/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
@@ -38,10 +38,8 @@ public class TimerService {
     private final CategoryRepository categoryRepository;
     private final TimerRepository timerRepository;
 
-    // 푸시알림 활성화가 필요한 로직이라면, FCMService를 주입!
-    private final FCMService fcmService;
 
-    private LocalDateTime now;
+    private final Locale locale = Locale.KOREA;
 
     @Transactional
     public void createTimer(Long userId, CreateTimerRequestDto createTimerRequestDto){
@@ -173,7 +171,7 @@ public class TimerService {
     // 완료된 타이머이고 알람이 켜져있는지 식별
     private boolean isCompletedTimer(Reminder reminder){
         // 현재 시간
-        now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now();
 
         LocalTime futureDateTime = LocalTime.from(now.plusHours(1));
         LocalTime pastDateTime = LocalTime.from(now.minusHours(1));
@@ -209,7 +207,7 @@ public class TimerService {
     // 인덱스로 요일 알아내기
     private String mapIndexToDayString(int index) {
         DayOfWeek dayOfWeek = DayOfWeek.of(index);
-        String dayName = dayOfWeek.getDisplayName(java.time.format.TextStyle.FULL, Locale.KOREAN);
+        String dayName = dayOfWeek.getDisplayName(java.time.format.TextStyle.FULL,locale);
 
         return dayName.substring(0, 1);
     }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #71 

## 📋 구현 기능 명세
- [x] 포맷함수 일일이 한국시간으로 설정해주는 방법보다 더 좋은 방법을 생각하다 어플리케이션 timezone을 사용하여 한국시간으로 설정하는 방법으로 고쳤습니다!

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지


- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
```java
결과 예시 사진 첨부
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/timer/main
