### PR TITLE
[Refactor] 클라 요청에 따른 카테고리 전체 조회 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 | Cloud Computing |	AWS EC2 (Ubuntu 22.04 LTS) |
 | Database | AWS RDS (MySQL 8.0.33) |
 | File Upload | AWS S3 |
+| MessageQueue | AWS SQS |
 | CI/CD | Github Actions, Docker, Nginx |
 | Notification | Firebase Cloud Messaging |
 | Monitoring  | Sentry, Slack |

--- a/linkmind/src/main/java/com/app/toaster/controller/CategoryController.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/CategoryController.java
@@ -3,14 +3,14 @@ package com.app.toaster.controller;
 import com.app.toaster.common.dto.ApiResponse;
 import com.app.toaster.config.UserId;
 import com.app.toaster.controller.request.category.*;
+import com.app.toaster.controller.response.category.CategoriesResponse;
 import com.app.toaster.controller.response.toast.ToastFilter;
-import com.app.toaster.controller.response.category.CategoriesReponse;
+import com.app.toaster.controller.response.category.CategoryResponse;
 import com.app.toaster.controller.response.category.GetCategoryResponseDto;
 import com.app.toaster.exception.Success;
 import com.app.toaster.service.category.CategoryService;
 import com.app.toaster.service.search.SearchService;
 import jakarta.validation.Valid;
-import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
@@ -49,7 +49,7 @@ public class CategoryController {
 
     @GetMapping("/all")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<List<CategoriesReponse>> getCategories(@UserId Long userId){
+    public ApiResponse<CategoriesResponse> getCategories(@UserId Long userId){
         return ApiResponse.success(Success.GET_CATEORIES_SUCCESS, categoryService.getCategories(userId));
     }
 

--- a/linkmind/src/main/java/com/app/toaster/controller/response/category/CategoriesResponse.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/response/category/CategoriesResponse.java
@@ -1,0 +1,9 @@
+package com.app.toaster.controller.response.category;
+
+import java.util.List;
+
+public record CategoriesResponse(Long toastNumberInEntire ,List<CategoryResponse> categories) {
+	public static CategoriesResponse of(Long toastNumberInEntire ,List<CategoryResponse> categories){
+		return new CategoriesResponse(toastNumberInEntire, categories);
+	}
+}

--- a/linkmind/src/main/java/com/app/toaster/controller/response/category/CategoryResponse.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/response/category/CategoryResponse.java
@@ -1,10 +1,9 @@
 package com.app.toaster.controller.response.category;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
-public record CategoriesReponse(
+public record CategoryResponse(
         Long categoryId,
         String categoryTitle,
         int toastNum) {

--- a/linkmind/src/main/java/com/app/toaster/controller/response/main/MainPageResponseDto.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/response/main/MainPageResponseDto.java
@@ -1,13 +1,11 @@
 package com.app.toaster.controller.response.main;
 
-import com.app.toaster.controller.response.category.CategoriesReponse;
-import com.app.toaster.controller.response.toast.WeekSiteDto;
-import com.app.toaster.domain.RecommendSite;
+import com.app.toaster.controller.response.category.CategoryResponse;
+
 import lombok.Builder;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Builder
-public record MainPageResponseDto(String nickname, int readToastNum, int allToastNum, List<CategoriesReponse> mainCategoryListDto) {
+public record MainPageResponseDto(String nickname, int readToastNum, int allToastNum, List<CategoryResponse> mainCategoryListDto) {
 }

--- a/linkmind/src/main/java/com/app/toaster/exception/Error.java
+++ b/linkmind/src/main/java/com/app/toaster/exception/Error.java
@@ -41,6 +41,11 @@ public enum Error {
 	INVALID_USER_ACCESS(HttpStatus.UNAUTHORIZED, "접근 권한이 없는 유저입니다."),
 
 	/**
+	 * 403 FORBIDDEN EXCEPTION
+	 */
+	UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "리소스에 대한 권한이 없습니다."),
+
+	/**
 	 * 422 UNPROCESSABLE_ENTITY
 	 */
 	UNPROCESSABLE_ENTITY_DELETE_EXCEPTION(HttpStatus.UNPROCESSABLE_ENTITY, "서버에서 요청을 이해해 삭제하려는 도중 문제가 생겼습니다."),

--- a/linkmind/src/main/java/com/app/toaster/exception/model/ForbiddenException.java
+++ b/linkmind/src/main/java/com/app/toaster/exception/model/ForbiddenException.java
@@ -1,0 +1,10 @@
+package com.app.toaster.exception.model;
+
+import com.app.toaster.exception.Error;
+
+public class ForbiddenException extends CustomException{
+	public ForbiddenException(Error error, String message) {
+		super(error, message);
+	}
+
+}

--- a/linkmind/src/main/java/com/app/toaster/service/UserService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/UserService.java
@@ -1,10 +1,10 @@
 package com.app.toaster.service;
 
-import com.app.toaster.controller.response.category.CategoriesReponse;
+import com.app.toaster.controller.response.category.CategoryResponse;
 import com.app.toaster.controller.response.main.MainPageResponseDto;
 import com.app.toaster.domain.Category;
 import com.app.toaster.infrastructure.CategoryRepository;
-import org.springframework.beans.factory.annotation.Value;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,7 +16,6 @@ import com.app.toaster.exception.model.BadRequestException;
 import com.app.toaster.exception.model.NotFoundException;
 import com.app.toaster.infrastructure.ToastRepository;
 import com.app.toaster.infrastructure.UserRepository;
-import com.app.toaster.service.toast.ToastService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -76,7 +75,7 @@ public class UserService {
                 .allToastNum(allToastNum)
                 .readToastNum(readToastNum)
                 .mainCategoryListDto(getCategory(user).stream()
-                .map(category -> CategoriesReponse.builder()
+                .map(category -> CategoryResponse.builder()
                         .categoryId(category.getCategoryId())
                         .categoryTitle(category.getTitle())
                         .toastNum(toastRepository.getAllByCategory(category).size()).build()

--- a/linkmind/src/main/java/com/app/toaster/service/category/CategoryService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/category/CategoryService.java
@@ -1,10 +1,11 @@
 package com.app.toaster.service.category;
 
 import com.app.toaster.controller.request.category.*;
+import com.app.toaster.controller.response.category.CategoriesResponse;
 import com.app.toaster.controller.response.category.DuplicatedResponse;
 import com.app.toaster.controller.response.toast.ToastDto;
 import com.app.toaster.controller.response.toast.ToastFilter;
-import com.app.toaster.controller.response.category.CategoriesReponse;
+import com.app.toaster.controller.response.category.CategoryResponse;
 import com.app.toaster.controller.response.category.GetCategoryResponseDto;
 import com.app.toaster.domain.Category;
 import com.app.toaster.domain.Toast;
@@ -12,7 +13,6 @@ import com.app.toaster.domain.User;
 import com.app.toaster.exception.Error;
 import com.app.toaster.exception.model.CustomException;
 import com.app.toaster.exception.model.NotFoundException;
-import com.app.toaster.exception.model.UnauthorizedException;
 import com.app.toaster.infrastructure.CategoryRepository;
 import com.app.toaster.infrastructure.ToastRepository;
 import com.app.toaster.infrastructure.UserRepository;
@@ -24,8 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -77,16 +75,17 @@ public class CategoryService {
 
     }
 
-    public List<CategoriesReponse> getCategories(final Long userId){
+    public CategoriesResponse getCategories(final Long userId){
         User presentUser = findUser(userId);
 
-        return categoryRepository.findAllByUserOrderByPriority(presentUser)
-                .stream()
-                .map(category -> CategoriesReponse.builder()
-                        .categoryId(category.getCategoryId())
-                        .categoryTitle(category.getTitle())
-                        .toastNum(toastRepository.getAllByCategory(category).size()).build()
-                ).collect(Collectors.toList());
+        return CategoriesResponse.of(toastRepository.countAllByUser(presentUser),categoryRepository.findAllByUserOrderByPriority(presentUser)
+            .stream()
+            .map(category -> CategoryResponse.builder()
+                .categoryId(category.getCategoryId())
+                .categoryTitle(category.getTitle())
+                .toastNum(toastRepository.getAllByCategory(category).size()).build()
+            ).collect(Collectors.toList()));
+
 
     }
 

--- a/linkmind/src/main/java/com/app/toaster/service/recommendSite/RecommendSiteService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/recommendSite/RecommendSiteService.java
@@ -1,19 +1,13 @@
 package com.app.toaster.service.recommendSite;
 
-import com.app.toaster.controller.response.category.CategoriesReponse;
-import com.app.toaster.controller.response.main.MainPageResponseDto;
 import com.app.toaster.domain.RecommendSite;
-import com.app.toaster.domain.User;
-import com.app.toaster.exception.Error;
-import com.app.toaster.exception.model.NotFoundException;
 import com.app.toaster.infrastructure.RecommedSiteRepository;
 import com.app.toaster.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
+
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/linkmind/src/main/java/com/app/toaster/service/toast/ToastService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/toast/ToastService.java
@@ -30,6 +30,7 @@ import com.app.toaster.domain.User;
 import com.app.toaster.exception.Error;
 import com.app.toaster.exception.model.BadRequestException;
 import com.app.toaster.exception.model.CustomException;
+import com.app.toaster.exception.model.ForbiddenException;
 import com.app.toaster.exception.model.NotFoundException;
 import com.app.toaster.exception.model.UnauthorizedException;
 import com.app.toaster.external.client.aws.ImagePresignedUrlResponse;
@@ -124,7 +125,7 @@ public class ToastService {
 			() -> new NotFoundException(Error.NOT_FOUND_TOAST_EXCEPTION, Error.NOT_FOUND_TOAST_EXCEPTION.getMessage())
 		);
 		if (!presentUser.equals(toast.getUser())){
-			throw new UnauthorizedException(Error.INVALID_USER_ACCESS, Error.INVALID_USER_ACCESS.getMessage());
+			throw new ForbiddenException(Error.UNAUTHORIZED_ACCESS, Error.UNAUTHORIZED_ACCESS.getMessage());
 		}
 		// BASIC_ROOT를 제외한 문자열을 추출합니다.
 		// String imageKey = toast.getThumbnailUrl().replace(BASIC_ROOT, "");


### PR DESCRIPTION
## 🚩 관련 이슈
- close #79 

## 📋 구현 기능 명세
- [x] category 전체조회 페이지 response 수정
- [x] 에러 코드 401 -> 403으로 변경

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
401로 하니까 엑세스토큰 로직과 겹치는 현상이 발생해서 403으로 로직을 변경했습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지
변수명 맘에 드는지

- 개발하면서 어떤 점이 궁금했는지
코드를 더 이쁘게 꾸밀 수 있을까 고민.

## 📸 결과물 스크린샷
```java
{
    "code": 200,
    "message": "전체 카테고리 조회 성공",
    "data": {
        "toastNumberInEntire": 5,
        "categories": [
            {
                "categoryId": 20,
                "categoryTitle": "fdsfadsf",
                "toastNum": 1
            },
            {
                "categoryId": 21,
                "categoryTitle": "점심 메뉴",
                "toastNum": 0
            },
            {
                "categoryId": 22,
                "categoryTitle": "점심 메뉴",
                "toastNum": 0
            },
            {
                "categoryId": 23,
                "categoryTitle": "Ggddf",
                "toastNum": 0
            },
            {
                "categoryId": 24,
                "categoryTitle": "Http",
                "toastNum": 0
            },
            {
                "categoryId": 25,
                "categoryTitle": "Gggg",
                "toastNum": 0
            },
            {
                "categoryId": 26,
                "categoryTitle": "Gggdf",
                "toastNum": 0
            },
            {
                "categoryId": 27,
                "categoryTitle": "Ffffff",
                "toastNum": 0
            }
        ]
    }
}
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/category/all
