### PR TITLE
[Fix] 리마인드가 존재하는 카테고리 삭제

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/domain/Reminder.java
+++ b/linkmind/src/main/java/com/app/toaster/domain/Reminder.java
@@ -25,8 +25,7 @@ public class Reminder extends BaseTimeEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	private User user;
 
-	@OneToOne
-	@JoinColumn(name = "category")
+	@OneToOne(cascade = CascadeType.REMOVE)
 	private Category category;
 
 	private LocalTime remindTime;

--- a/linkmind/src/main/java/com/app/toaster/infrastructure/TimerRepository.java
+++ b/linkmind/src/main/java/com/app/toaster/infrastructure/TimerRepository.java
@@ -14,4 +14,6 @@ public interface TimerRepository extends JpaRepository<Reminder, Long> {
     void deleteAllByUser(User user);
 
     ArrayList<Reminder> findAllByCategory(Category category);
+
+    Reminder findByCategory_CategoryId(Long categoryId);
 }

--- a/linkmind/src/main/java/com/app/toaster/service/category/CategoryService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/category/CategoryService.java
@@ -8,12 +8,14 @@ import com.app.toaster.controller.response.toast.ToastFilter;
 import com.app.toaster.controller.response.category.CategoryResponse;
 import com.app.toaster.controller.response.category.GetCategoryResponseDto;
 import com.app.toaster.domain.Category;
+import com.app.toaster.domain.Reminder;
 import com.app.toaster.domain.Toast;
 import com.app.toaster.domain.User;
 import com.app.toaster.exception.Error;
 import com.app.toaster.exception.model.CustomException;
 import com.app.toaster.exception.model.NotFoundException;
 import com.app.toaster.infrastructure.CategoryRepository;
+import com.app.toaster.infrastructure.TimerRepository;
 import com.app.toaster.infrastructure.ToastRepository;
 import com.app.toaster.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +37,7 @@ public class CategoryService {
     private final ToastRepository toastRepository;
 
     private final static int MAX_CATERGORY_NUMBER = 50;
+    private final TimerRepository timerRepository;
 
     @Transactional
     public void createCategory(final Long userId, final CreateCategoryDto createCategoryDto){
@@ -69,9 +72,11 @@ public class CategoryService {
                     .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_CATEGORY_EXCEPTION, Error.NOT_FOUND_CATEGORY_EXCEPTION.getMessage()));
 
             categoryRepository.decreasePriorityNextDeleteCategory(categoryId, category.getPriority());
-        }
 
-        categoryRepository.deleteALLByCategoryIdInQuery(deleteCategoryDto.deleteCategoryList());
+            Reminder timer = timerRepository.findByCategory_CategoryId(categoryId);
+
+            timerRepository.delete(timer);
+        }
 
     }
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #96 

## 📋 구현 기능 명세
- [x] 리마인드가 존재하는 카테고리 삭제

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
리마인드가 존재하는 카테고리르 삭제하려면 외래키 제약때문에 삭제가 안되는 오류 발생...
정확한 원인은 파악못했지만 timerReposiotry에서 timer 객체를 직접 delete하는것으로 해결...
``` java
categoryRepository.decreasePriorityNextDeleteCategory(categoryId, category.getPriority());

Reminder timer = timerRepository.findByCategory_CategoryId(categoryId);

timerRepository.delete(timer);
```

- 어떤 부분에 리뷰어가 집중해야 하는지
최적화 하기...😅

- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
<img width="625" alt="스크린샷 2024-01-16 오전 4 49 51" src="https://github.com/Link-MIND/TOASTER-Server/assets/92644651/a0cbce2a-d6ce-4926-a126-5a4149ed9e9b">

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/category
