### PR TITLE
[fix] 리마인드가 존재하지않는 카테고리 삭제

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/domain/Category.java
+++ b/linkmind/src/main/java/com/app/toaster/domain/Category.java
@@ -27,6 +27,9 @@ public class Category{
 
 	private int priority;
 
+	@OneToOne(cascade = CascadeType.REMOVE)
+	private Reminder reminder;
+
 	private LocalDateTime latestReadTime;
 
 	@Builder

--- a/linkmind/src/main/java/com/app/toaster/domain/Reminder.java
+++ b/linkmind/src/main/java/com/app/toaster/domain/Reminder.java
@@ -25,7 +25,7 @@ public class Reminder extends BaseTimeEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	private User user;
 
-	@OneToOne(cascade = CascadeType.REMOVE)
+	@OneToOne
 	private Category category;
 
 	private LocalTime remindTime;

--- a/linkmind/src/main/java/com/app/toaster/service/category/CategoryService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/category/CategoryService.java
@@ -74,8 +74,9 @@ public class CategoryService {
             categoryRepository.decreasePriorityNextDeleteCategory(categoryId, category.getPriority());
 
             Reminder timer = timerRepository.findByCategory_CategoryId(categoryId);
-
-            timerRepository.delete(timer);
+            if(timer != null)
+                timerRepository.delete(timer);
+            categoryRepository.delete(category);
         }
 
     }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #109 

## 📋 구현 기능 명세
- [x] 타이머 삭제시 관련 카테고리 삭제됨 이슈
- [x] 타이머가 없는 카테고리 삭제시 에러 이슈


## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
타이머 삭제시 카테고리도 함께 삭제되는 이슈 발생하여 cascade를 Reminder말고 Category에서 설정했습니다.
카테고리 삭제시 타이머도 함께 삭제하는데 이때 타이머가 없다면 에러가 발생 -> 타이머 없는 경우 처리

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
```java
결과 예시 사진 첨부
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- 
