### PR TITLE
[Feature] 카테고리 수정 API 두개로 분리

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/controller/CategoryController.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/CategoryController.java
@@ -65,11 +65,21 @@ public class CategoryController {
 
     @PatchMapping("/priority")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse editCategories(
+    public ApiResponse editCategoryPriority(
             @UserId Long userId,
             @RequestBody ChangeCateoryPriorityDto changeCateoryPriorityDto
     ){
-        categoryService.editCategoriePriority(changeCateoryPriorityDto);
+        categoryService.editCategoryPriority(changeCateoryPriorityDto);
+        return ApiResponse.success(Success.UPDATE_CATEGORY_TITLE_SUCCESS);
+    }
+
+    @PatchMapping("/title")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse editCategoryTitle(
+            @UserId Long userId,
+            @RequestBody ChangeCateoryTitleDto changeCateoryTitleDto
+    ){
+        categoryService.editCategoryTitle(changeCateoryTitleDto);
         return ApiResponse.success(Success.UPDATE_CATEGORY_TITLE_SUCCESS);
     }
 

--- a/linkmind/src/main/java/com/app/toaster/controller/CategoryController.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/CategoryController.java
@@ -53,16 +53,6 @@ public class CategoryController {
         return ApiResponse.success(Success.GET_CATEORIES_SUCCESS, categoryService.getCategories(userId));
     }
 
-//    @PatchMapping("/edit")
-//    @ResponseStatus(HttpStatus.OK)
-//    public ApiResponse editCategories(
-//            @UserId Long userId,
-//            @RequestBody EditCategoryRequestDto editCategoryRequestDto
-//    ){
-//        categoryService.editCategories(editCategoryRequestDto);
-//        return ApiResponse.success(Success.UPDATE_CATEGORY_TITLE_SUCCESS);
-//    }
-
     @PatchMapping("/priority")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse editCategoryPriority(

--- a/linkmind/src/main/java/com/app/toaster/controller/CategoryController.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/CategoryController.java
@@ -53,13 +53,23 @@ public class CategoryController {
         return ApiResponse.success(Success.GET_CATEORIES_SUCCESS, categoryService.getCategories(userId));
     }
 
-    @PatchMapping("/edit")
+//    @PatchMapping("/edit")
+//    @ResponseStatus(HttpStatus.OK)
+//    public ApiResponse editCategories(
+//            @UserId Long userId,
+//            @RequestBody EditCategoryRequestDto editCategoryRequestDto
+//    ){
+//        categoryService.editCategories(editCategoryRequestDto);
+//        return ApiResponse.success(Success.UPDATE_CATEGORY_TITLE_SUCCESS);
+//    }
+
+    @PatchMapping("/priority")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse editCategories(
             @UserId Long userId,
-            @RequestBody EditCategoryRequestDto editCategoryRequestDto
+            @RequestBody ChangeCateoryPriorityDto changeCateoryPriorityDto
     ){
-        categoryService.editCategories(editCategoryRequestDto);
+        categoryService.editCategoriePriority(changeCateoryPriorityDto);
         return ApiResponse.success(Success.UPDATE_CATEGORY_TITLE_SUCCESS);
     }
 

--- a/linkmind/src/main/java/com/app/toaster/infrastructure/CategoryRepository.java
+++ b/linkmind/src/main/java/com/app/toaster/infrastructure/CategoryRepository.java
@@ -23,8 +23,8 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     @Query("delete from Category c where c.categoryId in :ids")
     void deleteALLByCategoryIdInQuery(@Param("ids") List<Long> categoryIds);
 
-    @Query("SELECT COALESCE(MAX(c.priority), 0) FROM Category c")
-    int findMaxPriority();
+    @Query("SELECT COALESCE(MAX(c.priority), 0) FROM Category c WHERE c.user = :user")
+    int findMaxPriorityByUser(@Param("user") User user);
 
     ArrayList<Category> findAllByUserOrderByPriority(User user);
 

--- a/linkmind/src/main/java/com/app/toaster/infrastructure/CategoryRepository.java
+++ b/linkmind/src/main/java/com/app/toaster/infrastructure/CategoryRepository.java
@@ -18,11 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-    @Transactional
-    @Modifying
-    @Query("delete from Category c where c.categoryId in :ids")
-    void deleteALLByCategoryIdInQuery(@Param("ids") List<Long> categoryIds);
-
     @Query("SELECT COALESCE(MAX(c.priority), 0) FROM Category c WHERE c.user = :user")
     int findMaxPriorityByUser(@Param("user") User user);
 

--- a/linkmind/src/main/java/com/app/toaster/service/category/CategoryService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/category/CategoryService.java
@@ -148,7 +148,7 @@ public class CategoryService {
 
     //순서 업데이트
     @Transactional
-    public void editCategoriePriority(ChangeCateoryPriorityDto changeCateoryPriorityDto){
+    public void editCategoryPriority(ChangeCateoryPriorityDto changeCateoryPriorityDto){
 
         val newPriority = changeCateoryPriorityDto.newPriority();
 
@@ -164,6 +164,12 @@ public class CategoryService {
             categoryRepository.increasePriorityByOne(changeCateoryPriorityDto.categoryId(), currentPriority, newPriority);
 
 
+    }
+
+    @Transactional
+    public void editCategoryTitle(ChangeCateoryTitleDto changeCateoryTitleDto){
+
+        categoryRepository.updateCategoryTitle(changeCateoryTitleDto.categoryId(), changeCateoryTitleDto.newTitle());
     }
 
     //해당 유저 탐색

--- a/linkmind/src/main/java/com/app/toaster/service/category/CategoryService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/category/CategoryService.java
@@ -95,32 +95,6 @@ public class CategoryService {
 
     }
 
-    @Transactional
-    public void editCategories(final EditCategoryRequestDto editCategoryRequestDto){
-        //제목 업데이트
-        editCategoryRequestDto.changeCategoryTitleList().forEach(request ->
-                categoryRepository.updateCategoryTitle(request.categoryId(), request.newTitle()));
-
-        //순서 업데이트
-        for (ChangeCateoryPriorityDto changeCateoryPriorityDto : editCategoryRequestDto.changeCategoryPriorityList()) {
-            Long categoryId = changeCateoryPriorityDto.categoryId();
-            int newPriority = changeCateoryPriorityDto.newPriority();
-
-            Category category = categoryRepository.findById(categoryId)
-                    .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_CATEGORY_EXCEPTION, Error.NOT_FOUND_CATEGORY_EXCEPTION.getMessage()));
-
-            int currentPriority = category.getPriority();
-            category.updateCategoryPriority(changeCateoryPriorityDto.newPriority());
-
-            if(currentPriority < newPriority)
-                categoryRepository.decreasePriorityByOne(categoryId, currentPriority, newPriority);
-            else if (currentPriority > newPriority)
-                categoryRepository.increasePriorityByOne(categoryId, currentPriority, newPriority);
-
-        }
-
-    }
-
     public GetCategoryResponseDto getCategory(final Long userId, final Long categoryId, final ToastFilter filter) {
         User presentUser = findUser(userId);
         if (categoryId ==0){

--- a/linkmind/src/main/java/com/app/toaster/service/category/CategoryService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/category/CategoryService.java
@@ -43,8 +43,8 @@ public class CategoryService {
     public void createCategory(final Long userId, final CreateCategoryDto createCategoryDto){
         User presentUser = findUser(userId);
 
-        // 현재 최대 우선순위를 가져와서 새로운 우선순위를 설정
-        val maxPriority = categoryRepository.findMaxPriority();
+        // 현재 유저의 최대 우선순위를 가져와서 새로운 우선순위를 설정
+        val maxPriority = categoryRepository.findMaxPriorityByUser(presentUser);
 
         val categoryNum= categoryRepository.findAllByUser(presentUser).size();
 
@@ -144,6 +144,26 @@ public class CategoryService {
             .allToastNum(toasts.size())
             .toastListDto(toastListDto)
             .build();
+    }
+
+    //순서 업데이트
+    @Transactional
+    public void editCategoriePriority(ChangeCateoryPriorityDto changeCateoryPriorityDto){
+
+        val newPriority = changeCateoryPriorityDto.newPriority();
+
+        Category category = categoryRepository.findById(changeCateoryPriorityDto.categoryId())
+                .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_CATEGORY_EXCEPTION, Error.NOT_FOUND_CATEGORY_EXCEPTION.getMessage()));
+
+        int currentPriority = category.getPriority();
+        category.updateCategoryPriority(changeCateoryPriorityDto.newPriority());
+
+        if(currentPriority < newPriority)
+            categoryRepository.decreasePriorityByOne(changeCateoryPriorityDto.categoryId(), currentPriority, newPriority);
+        else if (currentPriority > newPriority)
+            categoryRepository.increasePriorityByOne(changeCateoryPriorityDto.categoryId(), currentPriority, newPriority);
+
+
     }
 
     //해당 유저 탐색


### PR DESCRIPTION
## 🚩 관련 이슈
- close #113 

## 📋 구현 기능 명세
- [x] 우선순위 편집 api 
- [x] 제목 편집 api

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
기존 로직중 우선순위를 정할때 유저별로 우선순위를 반영하는게 아니라 모든 카테고리에서 우선순위를 정했었는데
이러면 클라에서 변경 우선순위를 보내줬을때 이상하게 우선순위가 변경되어서 카테고리 생성시 우선순위를 현재유저의 우선순위 max +1 값으로 변경했습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
<img width="646" alt="스크린샷 2024-01-16 오후 11 37 19" src="https://github.com/Link-MIND/TOASTER-Server/assets/92644651/35cd3670-0595-4828-8d6f-b0879f77386f">
<img width="584" alt="스크린샷 2024-01-16 오후 11 37 59" src="https://github.com/Link-MIND/TOASTER-Server/assets/92644651/28bef898-a53e-4103-965b-f1096d1dee30">


## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/category/title
- baseurl/category/priority
