### PR TITLE
[fix] @TitleValid 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@
 
 <br>
 
-## 📜서버 API 명세서
-명세서 보러가기 : [API Docs](https://www.notion.so/API-005abc837a1a4f54b88da402ae031ef2)
-<br><br>
 
 ## 📦 ERD
 <img width="752" alt="스크린샷 2024-01-08 오전 12 27 24" src="https://github.com/Link-MIND/TOASTER-Server/assets/92644651/2c749077-5136-4578-9002-c1d244b7cab7">

--- a/linkmind/src/main/java/com/app/toaster/controller/CategoryController.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/CategoryController.java
@@ -67,7 +67,7 @@ public class CategoryController {
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse editCategoryTitle(
             @UserId Long userId,
-            @RequestBody ChangeCateoryTitleDto changeCateoryTitleDto
+            @Valid @RequestBody ChangeCateoryTitleDto changeCateoryTitleDto
     ){
         categoryService.editCategoryTitle(changeCateoryTitleDto);
         return ApiResponse.success(Success.UPDATE_CATEGORY_TITLE_SUCCESS);

--- a/linkmind/src/main/java/com/app/toaster/controller/request/category/ChangeCateoryTitleDto.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/request/category/ChangeCateoryTitleDto.java
@@ -1,10 +1,11 @@
 package com.app.toaster.controller.request.category;
 
+import com.app.toaster.controller.valid.Severity;
+import com.app.toaster.controller.valid.TitleValid;
 import jakarta.validation.constraints.NotNull;
 
 public record ChangeCateoryTitleDto(
         @NotNull
         Long categoryId,
-        @NotNull
-        String newTitle) {
+        @TitleValid(payload = Severity.Error.class) @NotNull String newTitle) {
 }

--- a/linkmind/src/main/java/com/app/toaster/controller/request/category/EditCategoryRequestDto.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/request/category/EditCategoryRequestDto.java
@@ -1,8 +1,0 @@
-package com.app.toaster.controller.request.category;
-
-import java.util.ArrayList;
-
-public record EditCategoryRequestDto (
-        ArrayList<ChangeCateoryTitleDto> changeCategoryTitleList,
-        ArrayList<ChangeCateoryPriorityDto> changeCategoryPriorityList){
-}

--- a/linkmind/src/main/java/com/app/toaster/controller/valid/TitleValidator.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/valid/TitleValidator.java
@@ -39,7 +39,7 @@ public class TitleValidator implements ConstraintValidator<TitleValid, String> {
 			return false;
 		}
 
-		if(title.length()>=15){
+		if(title.length()>15){
 			context.buildConstraintViolationWithTemplate("이름은 최대 15자까지 입력 가능해요")
 					.addConstraintViolation();
 			return false;


### PR DESCRIPTION
## 🚩 관련 이슈
- close #118 

## 📋 구현 기능 명세
- [x] TitleValid 수정

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
TitleValid의 글자수 '>=15' 되어있어서 15자도 안되는 오류 발생 -> '=' 제거
TitleValid createCategory에만 적용되어있고 카테고리 제목 편집에는 안붙여져있어서 편집 api에도 적용하였습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
<img width="802" alt="스크린샷 2024-01-17 오전 12 27 36" src="https://github.com/Link-MIND/TOASTER-Server/assets/92644651/f59d7d03-9cd2-47da-b35f-c2e294f5408b">
<img width="542" alt="스크린샷 2024-01-17 오전 12 30 57" src="https://github.com/Link-MIND/TOASTER-Server/assets/92644651/4b0b05d5-487b-4135-8dd1-6c39126da55e">



## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/category
- baseurl/category/title
