### PR TITLE
[Fix] 전체카테고리 리마인더 생성가능하게 변경

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/controller/response/timer/CompletedTimerDto.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/response/timer/CompletedTimerDto.java
@@ -8,6 +8,8 @@ import java.util.List;
 
 public record CompletedTimerDto(Long timerId, Long categoryId, String remindTime, String remindDate, String comment) {
     public static CompletedTimerDto of(Reminder timer,String remindTime, String remindDate){
+        if(timer.getCategory() == null)
+            return new CompletedTimerDto(timer.getId(), 0L, remindTime, remindDate, "전체");
         return new CompletedTimerDto(timer.getId(), timer.getCategory().getCategoryId(), remindTime, remindDate, timer.getComment() );
     }
 }

--- a/linkmind/src/main/java/com/app/toaster/controller/response/timer/WaitingTimerDto.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/response/timer/WaitingTimerDto.java
@@ -8,6 +8,8 @@ import java.util.List;
 
 public record WaitingTimerDto(Long timerId, String remindTime, String remindDates, Boolean isAlarm, LocalDateTime updateAt, String comment, Long categoryId) {
     public static WaitingTimerDto of(Reminder timer, String remindTime, String remindDates) {
+        if(timer.getCategory() == null)
+            return new WaitingTimerDto(timer.getId(), remindTime, remindDates, timer.getIsAlarm(), timer.getUpdateAt(), "전체", 0L);
         return new WaitingTimerDto(timer.getId(), remindTime, remindDates, timer.getIsAlarm(), timer.getUpdateAt(), timer.getComment(), timer.getCategory().getCategoryId());
     }
 }

--- a/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
@@ -49,6 +49,8 @@ public class TimerService {
     @Transactional
     public void createTimer(Long userId, CreateTimerRequestDto createTimerRequestDto){
         User presentUser = findUser(userId);
+        Category category = null;
+        String comment = "전체";
 
         int timerNum = timerRepository.findAllByUser(presentUser).size();
 
@@ -56,8 +58,11 @@ public class TimerService {
             throw new CustomException(Error.UNPROCESSABLE_ENTITY_CREATE_TIMER_EXCEPTION, Error.UNPROCESSABLE_ENTITY_CREATE_TIMER_EXCEPTION.getMessage());
         }
 
-        Category category = categoryRepository.findById(createTimerRequestDto.categoryId())
-                .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_CATEGORY_EXCEPTION, Error.NOT_FOUND_CATEGORY_EXCEPTION.getMessage()));
+        if(createTimerRequestDto.categoryId() != 0) {
+            category = categoryRepository.findById(createTimerRequestDto.categoryId())
+                    .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_CATEGORY_EXCEPTION, Error.NOT_FOUND_CATEGORY_EXCEPTION.getMessage()));
+            comment = category.getTitle();
+        }
 
         if(!timerRepository.findAllByCategory(category).isEmpty()){
             throw new CustomException(Error.UNPROCESSABLE_CREATE_TIMER_EXCEPTION, Error.UNPROCESSABLE_CREATE_TIMER_EXCEPTION.getMessage());
@@ -69,7 +74,7 @@ public class TimerService {
                 .remindDates(createTimerRequestDto.remindDates())
                 .remindTime(LocalTime.parse(createTimerRequestDto.remindTime()))
                 .isAlarm(true)
-                .comment(category.getTitle())
+                .comment(comment)
                 .build();
 
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #123 

## 📋 구현 기능 명세
- [x] 전체카테고리의 리마인더 생성
- [x] 리마인더 조회시 카테고리 null 처리

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
전체카테고리의 리마인더 생성할 수 있도록 카테고리 id를 0으로하면 category에 null값을 추가했습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
<img width="544" alt="스크린샷 2024-01-17 오전 1 14 11" src="https://github.com/Link-MIND/TOASTER-Server/assets/92644651/283b132d-380c-449d-8057-4c3849f00eac">
<img width="542" alt="스크린샷 2024-01-17 오전 12 30 57" src="https://github.com/Link-MIND/TOASTER-Server/assets/92644651/89de4d4f-fba3-4b58-a5b1-0108be01b4ec">


## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/category
