### PR TITLE
[fix] 유저별 전체카테고리 중복체크

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/infrastructure/TimerRepository.java
+++ b/linkmind/src/main/java/com/app/toaster/infrastructure/TimerRepository.java
@@ -13,7 +13,7 @@ public interface TimerRepository extends JpaRepository<Reminder, Long> {
     ArrayList<Reminder> findAllByUser(User user);
     void deleteAllByUser(User user);
 
-    ArrayList<Reminder> findAllByCategory(Category category);
+    ArrayList<Reminder> findAllByCategoryAndUser(Category category, User user);
 
     Reminder findByCategory_CategoryId(Long categoryId);
 }

--- a/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
@@ -63,8 +63,7 @@ public class TimerService {
                     .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_CATEGORY_EXCEPTION, Error.NOT_FOUND_CATEGORY_EXCEPTION.getMessage()));
             comment = category.getTitle();
         }
-
-        if(!timerRepository.findAllByCategory(category).isEmpty()){
+        if(!timerRepository.findAllByCategoryAndUser(category,presentUser).isEmpty()){
             throw new CustomException(Error.UNPROCESSABLE_CREATE_TIMER_EXCEPTION, Error.UNPROCESSABLE_CREATE_TIMER_EXCEPTION.getMessage());
         }
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #123 

## 📋 구현 기능 명세
- [x] 카테고리 중복체크를 카테고리 아이디로만 하니까 카테고리 0인 경우 중복에러가 나서 유저도 포함해서 중복체크하는 로직으로 바꿨습니다.

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지


- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
<img width="622" alt="스크린샷 2024-01-17 오전 3 17 56" src="https://github.com/Link-MIND/TOASTER-Server/assets/92644651/7c5953e0-30ad-4272-87ad-6657991b72a0">


## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/timer
