### PR TITLE
[#139] refactor: deleteCategory 쿼리파라미터로 변경

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/controller/CategoryController.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/CategoryController.java
@@ -11,11 +11,13 @@ import com.app.toaster.exception.Success;
 import com.app.toaster.service.category.CategoryService;
 import com.app.toaster.service.search.SearchService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -41,7 +43,7 @@ public class CategoryController {
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse deleteCategory(
             @UserId Long userId,
-            @RequestBody DeleteCategoryDto deleteCategoryDto
+            @NotNull @RequestParam(value = "deleteCategoryDto") ArrayList<Long> deleteCategoryDto
     ){
         categoryService.deleteCategory(deleteCategoryDto);
         return ApiResponse.success(Success.DELETE_CATEGORY_SUCCESS);

--- a/linkmind/src/main/java/com/app/toaster/service/auth/AuthService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/AuthService.java
@@ -45,8 +45,8 @@ public class AuthService {
 	private final SlackApi slackApi;
 
 
-	private final Long TOKEN_EXPIRATION_TIME_ACCESS =  5 * 60 * 1000L; //5분
-	private final Long TOKEN_EXPIRATION_TIME_REFRESH = 10* 60 * 1000L; //10분
+	private final Long TOKEN_EXPIRATION_TIME_ACCESS =  3*24*60 * 60 * 1000L; //3일
+	private final Long TOKEN_EXPIRATION_TIME_REFRESH = 8*24*60 * 60 * 1000L; //8일
 	@Value("${static-image.root}")
 	private String BASIC_ROOT;
 

--- a/linkmind/src/main/java/com/app/toaster/service/category/CategoryService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/category/CategoryService.java
@@ -12,6 +12,7 @@ import com.app.toaster.domain.Reminder;
 import com.app.toaster.domain.Toast;
 import com.app.toaster.domain.User;
 import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.BadRequestException;
 import com.app.toaster.exception.model.CustomException;
 import com.app.toaster.exception.model.NotFoundException;
 import com.app.toaster.infrastructure.CategoryRepository;
@@ -63,11 +64,14 @@ public class CategoryService {
     }
 
     @Transactional
-    public void deleteCategory(final DeleteCategoryDto deleteCategoryDto){
+    public void deleteCategory(final ArrayList<Long> deleteCategoryDto){
+        if(deleteCategoryDto.isEmpty()){
+            throw new BadRequestException(Error.BAD_REQUEST_VALIDATION, Error.BAD_REQUEST_VALIDATION.getMessage());
+        }
 
-        toastRepository.updateCategoryIdsToNull(deleteCategoryDto.deleteCategoryList());
+        toastRepository.updateCategoryIdsToNull(deleteCategoryDto);
 
-        for (Long categoryId : deleteCategoryDto.deleteCategoryList()) {
+        for (Long categoryId : deleteCategoryDto) {
             Category category = categoryRepository.findById(categoryId)
                     .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_CATEGORY_EXCEPTION, Error.NOT_FOUND_CATEGORY_EXCEPTION.getMessage()));
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #139 

## 📋 구현 기능 명세
- [x] deleteCategory 쿼리 파라미터로 변경

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
안드쪽에서 delete로 리스트 레코드로 보내지 못해서 생각해보니 delete 요청도 where 절로만 쿼리를 날릴 수 있는 것 같아서 쿼리파라미터로 수정했습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지
레코드로 따로 매핑할 수 있을지


## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/category
