### PR TITLE
[#142] refactor: 회원탈퇴 다시 구현

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/controller/AuthController.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/AuthController.java
@@ -52,8 +52,8 @@ public class AuthController {
 
 	@DeleteMapping("/withdraw")
 	@ResponseStatus(HttpStatus.OK)
-	public ApiResponse withdraw(@UserId Long userId, @RequestHeader("Authorization") String socialAccessToken) {
-		authService.withdraw(userId,socialAccessToken);
+	public ApiResponse withdraw(@UserId Long userId) {
+		authService.withdraw(userId);
 		return ApiResponse.success(Success.DELETE_USER_SUCCESS);
 	}
 }

--- a/linkmind/src/main/java/com/app/toaster/service/auth/AuthService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/AuthService.java
@@ -131,12 +131,12 @@ public class AuthService {
 	}
 
 	@Transactional
-	public void withdraw(Long userId, String accessToken) {
+	public void withdraw(Long userId) {
 		User user = userRepository.findByUserId(userId).orElseThrow(
 			()->new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
-		if (user.getSocialType() == SocialType.KAKAO){
-			kakaoSignInService.withdrawKakao(accessToken);
-		}
+		// if (user.getSocialType() == SocialType.KAKAO){
+		// 	kakaoSignInService.withdrawKakao(accessToken);
+		// }
 		try {
 			toastService.deleteAllToast(user);
 		}catch (IOException e){

--- a/linkmind/src/main/java/com/app/toaster/service/auth/kakao/KakaoSignInService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/kakao/KakaoSignInService.java
@@ -34,13 +34,14 @@ public class KakaoSignInService {
 		return LoginResult.of(objectMapper.convertValue(responseData.getBody(), Map.class).get("id").toString(), profileResponse==null?null:profileResponse.get("profile_image").toString(),
 			profileResponse==null?null:profileResponse.get("nickname").toString()); //프로필 이미지 허용 x시 null로 넘기기.
 	}
+	// 인가코드 나중에 서버에서 한번에 처리 하는 방식으로 변경. ux 이슈
 
-	public String withdrawKakao(String accessToken){
-		ResponseEntity<Object> responseData = requestKakaoServer(accessToken, Strategy.WITHDRAWAL);
-		ObjectMapper objectMapper = new ObjectMapper();
-		HashMap profileResponse = (HashMap)objectMapper.convertValue( responseData.getBody(),Map.class);
-		return profileResponse.get("id").toString();
-	}
+	// public String withdrawKakao(String accessToken){
+	// 	ResponseEntity<Object> responseData = requestKakaoServer(accessToken, Strategy.WITHDRAWAL);
+	// 	ObjectMapper objectMapper = new ObjectMapper();
+	// 	HashMap profileResponse = (HashMap)objectMapper.convertValue( responseData.getBody(),Map.class);
+	// 	return profileResponse.get("id").toString();
+	// }
 
 	private ResponseEntity<Object> requestKakaoServer(String accessToken, Strategy strategy){
 		RestTemplate restTemplate = new RestTemplate();


### PR DESCRIPTION
## 🚩 관련 이슈
- close #142 

## 📋 구현 기능 명세
- [x] 회원탈퇴 부분 다시 구현

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
ux로 인한 변경

- 어떤 부분에 리뷰어가 집중해야 하는지
회원탈퇴에 문제 없는지

- 개발하면서 어떤 점이 궁금했는지
회원탈퇴 시 엑세스토큰을 사용하지 않고 다른 방법을 사용할 수 있는지. 카카오톡 서버 토큰을 만료 시간이 짧은데 저장을 해놔야되는가.

## 📸 결과물 스크린샷
```java
{
    "code": 200,
    "message": "회원 탈퇴가 정상적으로 이루어졌습니다.",
    "data": null
}
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/auth/withdraw
