### PR TITLE
[Feature] 예약된 스케줄링 모두 제거하는 test api 

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/domain/Reminder.java
+++ b/linkmind/src/main/java/com/app/toaster/domain/Reminder.java
@@ -10,6 +10,7 @@ import org.springframework.cglib.core.Local;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +18,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Reminder extends BaseTimeEntity {
+public class Reminder{
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	Long id;
@@ -36,6 +37,8 @@ public class Reminder extends BaseTimeEntity {
 	private String comment;
 
 	private Boolean isAlarm;
+
+	private LocalDateTime updateAt = LocalDateTime.now();
 
 	@Builder
 	public Reminder(User user, Category category, String comment, LocalTime remindTime, ArrayList<Integer> remindDates, Boolean isAlarm) {
@@ -61,6 +64,10 @@ public class Reminder extends BaseTimeEntity {
 
 	public void changeAlarm(){
 		this.isAlarm = !isAlarm;
+	}
+
+	public void setUpdatedAtNow(){
+		this.updateAt = LocalDateTime.now();
 	}
 
 }

--- a/linkmind/src/main/java/com/app/toaster/exception/Success.java
+++ b/linkmind/src/main/java/com/app/toaster/exception/Success.java
@@ -49,6 +49,7 @@ public enum Success {
 	CHANGE_TIMER_ALARM_SUCCESS(HttpStatus.OK, "타이머 알람여부 수정 완료"),
 	PUSH_ALARM_PERIODIC_SUCCESS(HttpStatus.OK, "푸시알림 활성에 성공했습니다."),
 	PUSH_ALARM_SUCCESS(HttpStatus.OK, "푸시알림 전송에 성공했습니다."),
+	CLEAR_SCHEDULED_TASKS_SUCCESS(HttpStatus.OK, "스케줄러에서 예약된 작업을 제거했습니다."),
 
 
 	/**

--- a/linkmind/src/main/java/com/app/toaster/external/client/fcm/FCMController.java
+++ b/linkmind/src/main/java/com/app/toaster/external/client/fcm/FCMController.java
@@ -6,11 +6,14 @@ import com.app.toaster.external.client.fcm.FCMPushRequestDto;
 import com.app.toaster.exception.Success;
 import com.app.toaster.external.client.fcm.FCMService;
 import lombok.RequiredArgsConstructor;
+import org.checkerframework.checker.units.qual.A;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+
+import static com.app.toaster.external.client.fcm.FCMService.clearScheduledTasks;
 
 @RestController
 @RequestMapping("/alarm")
@@ -41,5 +44,12 @@ public class FCMController {
     public ApiResponse sendTopicScheduledTest(@RequestBody FCMPushRequestDto request) {
         sqsProducer.sendMessage(request);
         return ApiResponse.success(Success.PUSH_ALARM_PERIODIC_SUCCESS);
+    }
+
+    @DeleteMapping("/clear")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse deleteScheduledTasks(){
+        clearScheduledTasks();
+        return ApiResponse.success(Success.CLEAR_SCHEDULED_TASKS_SUCCESS);
     }
 }

--- a/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
@@ -112,6 +112,8 @@ public class TimerService {
         }
         reminder.updateRemindDates(updateTimerDateTimeDto.remindDates());
         reminder.updateRemindTime(updateTimerDateTimeDto.remindTime());
+
+        reminder.setUpdatedAtNow();
         em.flush();
 
         LocalDateTime now = LocalDateTime.now();
@@ -139,6 +141,7 @@ public class TimerService {
         }
 
         reminder.updateComment(updateTimerCommentDto.newComment());
+        reminder.setUpdatedAtNow();
 
     }
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #152 

## 📋 구현 기능 명세
- [x] 예약된 스케줄링 모두 제거하는 test api 

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
예약된 스테줄링이 있으면 reminder 테이블이 drop되지않아서 모두 제거하는 test api를 구현하였습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
<img width="682" alt="스크린샷 2024-01-18 오전 4 58 39" src="https://github.com/Link-MIND/TOASTER-Server/assets/92644651/58c02a18-98f6-4359-a3d1-ffd959e5aa65">


## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/alarm/clear
