### PR TITLE
[fix]: 대기중인 시간 오름차순 정렬

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
@@ -157,6 +157,7 @@ public class TimerService {
         }
 
         reminder.changeAlarm();
+        reminder.setUpdatedAtNow();
     }
 
 

--- a/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
@@ -190,7 +190,7 @@ public class TimerService {
                 .map(this::createWaitingTimerDto)
                 .sorted(
                         Comparator.comparing(WaitingTimerDto::isAlarm)
-                                .thenComparing(WaitingTimerDto::updateAt).reversed()
+                                .thenComparing(WaitingTimerDto::updateAt)
                 )
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #151 

## 📋 구현 기능 명세
- [x] 대기중인 시간 오름차순 정렬

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
정렬을 할때 LocalDateTime이 오래된순으로 정렬해야했는데 최신순으로 정렬해서 이상해짐

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지
BaseEntity를 사용하여 createAt이라는 안쓰는 필드 생기는것이 더 나은지 
혹은 타이머가 수정될때마다 updateAt 바꿔주는 코드를 다 넣는게 나을지 고민이였습니다.

## 📸 결과물 스크린샷
```java
결과 예시 사진 첨부
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/timer/main
