### PR TITLE
[Fix] 알람 켜진 여부 정렬 반대조건으로 바꾸기

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
@@ -190,7 +190,7 @@ public class TimerService {
                 .filter(reminder -> !isCompletedTimer(reminder))
                 .map(this::createWaitingTimerDto)
                 .sorted(
-                        Comparator.comparing(WaitingTimerDto::isAlarm)
+                        Comparator.comparing((WaitingTimerDto dto) -> !dto.isAlarm())
                                 .thenComparing(WaitingTimerDto::updateAt)
                 )
                 .collect(Collectors.toList());


### PR DESCRIPTION
## 🚩 관련 이슈
- close #151 

## 📋 구현 기능 명세
- [x] 알람이 켜진것부터 정렬시키기

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
``` java
.sorted(
                        Comparator.comparing((WaitingTimerDto::isAlarm())
                                .thenComparing(WaitingTimerDto::updateAt)
                )
```
다음과 같이 하면 알람이 켜진순이 먼저 일줄아았는데 꺼진순이 먼저라 아래와 같이 코드를 변경했습니다.
``` java
.sorted(
                        Comparator.comparing((WaitingTimerDto dto) -> !dto.isAlarm())
                                .thenComparing(WaitingTimerDto::updateAt)
                )
```

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지
