### PR TITLE
[fix] 클립 최대 개수 제한 조건 변경

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/infrastructure/CategoryRepository.java
+++ b/linkmind/src/main/java/com/app/toaster/infrastructure/CategoryRepository.java
@@ -60,4 +60,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     Boolean existsCategoriesByUserAndTitle(User user, String title);
 
+    Long countAllByUser(User user);
+
 }

--- a/linkmind/src/main/java/com/app/toaster/service/category/CategoryService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/category/CategoryService.java
@@ -47,9 +47,10 @@ public class CategoryService {
         // 현재 유저의 최대 우선순위를 가져와서 새로운 우선순위를 설정
         val maxPriority = categoryRepository.findMaxPriorityByUser(presentUser);
 
-        val categoryNum= categoryRepository.findAllByUser(presentUser).size();
+        val categoryNum= categoryRepository.countAllByUser(presentUser);
+        System.out.println(categoryNum);
 
-        if(categoryNum > MAX_CATERGORY_NUMBER){
+        if(categoryNum >= MAX_CATERGORY_NUMBER){
             throw new CustomException(Error.BAD_REQUEST_CREATE_CLIP_EXCEPTION, Error.BAD_REQUEST_CREATE_CLIP_EXCEPTION.getMessage());
         }
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #160 

## 📋 구현 기능 명세
- [x] 클립 최대 개수 제한 조건 변경

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
최대 15개 클립 추가 가능인데 > 조건으로 예외처리를 해서 16개까지 들어가는 오류가 발생했습니다 '>=' 조건으로 변경하여 16개부터 에러를 보내주어 고쳤습니다!

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/category
