### PR TITLE
[Fix] 클립 총 개수 세는 로직 변경

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/infrastructure/ToastRepository.java
+++ b/linkmind/src/main/java/com/app/toaster/infrastructure/ToastRepository.java
@@ -36,6 +36,8 @@ public interface ToastRepository extends JpaRepository<Toast, Long> {
 
     Long countAllByUser(User user);
 
+    Long countAllByCategory(Category category);
+
     Long countALLByUserAndIsReadTrue(User user);
 
     Long countAllByUserAndIsReadFalse(User user);

--- a/linkmind/src/main/java/com/app/toaster/service/search/SearchService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/search/SearchService.java
@@ -47,7 +47,7 @@ public class SearchService {
 					toast -> ToastDto.of(toast))
 				.collect(Collectors.toList()),
 			searchCategoryList.stream().map(
-					category -> CategoryResult.of(category.getCategoryId(), category.getTitle(),toastRepository.countAllByUser(presentUser)))
+					category -> CategoryResult.of(category.getCategoryId(), category.getTitle(),toastRepository.countAllByCategory(category)))
 				.collect(Collectors.toList())
 			));
 	}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #165

## 📋 구현 기능 명세
- [x] 클립 총 개수 세는 로직 변경

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
서치할때 결과로 나오는 카테고리 수가 유저의 모든 카테고리수로 나오는 오류 발생
-> 특정 카테고리 토스터 총 개수로 변경

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
```java
결과 예시 사진 첨부
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/main/search?query=
