### PR TITLE
[Refactor/#170] 카카오톡에서 프로필 사진 안가져오기

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/service/auth/AuthService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/AuthService.java
@@ -85,7 +85,9 @@ public class AuthService {
 
 		user.updateRefreshToken(refreshToken);
 		user.updateFcmToken(fcmToken);
-		user.updateProfile(profileImage == null ? BASIC_ROOT+BASIC_THUMBNAIL : profileImage);
+		// user.updateProfile(profileImage == null ? BASIC_ROOT+BASIC_THUMBNAIL : profileImage);
+		user.updateProfile(BASIC_ROOT+BASIC_THUMBNAIL);
+
 		if (nickname!=null){		//탈퇴 안했던 유저들도 수정될 수 있도록 변경
 			user.updateNickname(nickname);
 		}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #170 

## 📋 구현 기능 명세
- [x] 기본 이미지로 설정

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
기본이미지로 설정.