### PR TITLE
[#181] refactor: 카테고리 열람 여부에 따른 전체 개수 수정

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/infrastructure/ToastRepository.java
+++ b/linkmind/src/main/java/com/app/toaster/infrastructure/ToastRepository.java
@@ -1,14 +1,15 @@
 package com.app.toaster.infrastructure;
 
-
 import com.app.toaster.domain.Category;
 import com.app.toaster.domain.User;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import com.app.toaster.domain.Category;
 import com.app.toaster.domain.Toast;
 import com.app.toaster.domain.User;
+
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,40 +19,45 @@ import java.util.ArrayList;
 import java.util.List;
 
 public interface ToastRepository extends JpaRepository<Toast, Long> {
-    ArrayList<Toast> getAllByCategory(Category category);
-    ArrayList<Toast> findByIsReadAndCategory(Boolean isRead, Category category);
+	ArrayList<Toast> getAllByCategory(Category category);
 
-    ArrayList<Toast> getAllByUser(User user);
+	ArrayList<Toast> findByIsReadAndCategory(Boolean isRead, Category category);
 
-    ArrayList<Toast> getAllByUserAndIsReadIsTrue(User user);
+	ArrayList<Toast> getAllByUser(User user);
 
-    @Modifying
-    @Query("UPDATE Toast t SET t.category = null WHERE t.category.categoryId IN :categoryIds")
-    void updateCategoryIdsToNull(@Param("categoryIds") List<Long> categoryIds);
+	ArrayList<Toast> getAllByUserAndIsReadIsTrue(User user);
 
-    @Query("SELECT t FROM Toast t WHERE " +
-      "t.user.userId = :userId and " +
-      "t.title LIKE CONCAT('%',:query, '%')"
-    )
-    List<Toast> searchToastsByQuery(Long userId, String query);
+	@Modifying
+	@Query("UPDATE Toast t SET t.category = null WHERE t.category.categoryId IN :categoryIds")
+	void updateCategoryIdsToNull(@Param("categoryIds") List<Long> categoryIds);
 
-    Long countAllByUser(User user);
+	@Query("SELECT t FROM Toast t WHERE " +
+		"t.user.userId = :userId and " +
+		"t.title LIKE CONCAT('%',:query, '%')"
+	)
+	List<Toast> searchToastsByQuery(Long userId, String query);
 
-    Long countAllByCategory(Category category);
+	Long countAllByUser(User user);
 
-    Long countALLByUserAndIsReadTrue(User user);
+	Long countALLByUserAndIsReadTrue(User user);
 
-    Long countAllByUserAndIsReadFalse(User user);
+	Long countALLByUserAndIsReadFalse(User user);
 
-    @Query("SELECT COUNT(t) FROM Toast t WHERE t.user.userId = :userId AND t.isRead = false")
-    Integer getUnReadToastNumber(Long userId);
+	Long countAllByCategory(Category category);
 
-    @Query("SELECT COUNT(t) FROM Toast t WHERE t.createdAt >= :startOfWeek AND t.createdAt <= :endOfWeek")
-    Long countAllByCreatedAtThisWeek(@Param("startOfWeek") LocalDateTime startOfWeek,
-                            @Param("endOfWeek") LocalDateTime endOfWeek);
+	Long countAllByCategoryAndIsReadTrue(Category category);
 
-    @Query("SELECT COUNT(t) FROM Toast t WHERE t.isRead = true AND t.updateAt >= :startOfWeek AND t.updateAt <= :endOfWeek")
-    Long countAllByUpdateAtThisWeek(@Param("startOfWeek") LocalDateTime startOfWeek,
-                                     @Param("endOfWeek") LocalDateTime endOfWeek);
+	Long countAllByCategoryAndIsReadFalse(Category category);
+
+	@Query("SELECT COUNT(t) FROM Toast t WHERE t.user.userId = :userId AND t.isRead = false")
+	Integer getUnReadToastNumber(Long userId);
+
+	@Query("SELECT COUNT(t) FROM Toast t WHERE t.createdAt >= :startOfWeek AND t.createdAt <= :endOfWeek")
+	Long countAllByCreatedAtThisWeek(@Param("startOfWeek") LocalDateTime startOfWeek,
+		@Param("endOfWeek") LocalDateTime endOfWeek);
+
+	@Query("SELECT COUNT(t) FROM Toast t WHERE t.isRead = true AND t.updateAt >= :startOfWeek AND t.updateAt <= :endOfWeek")
+	Long countAllByUpdateAtThisWeek(@Param("startOfWeek") LocalDateTime startOfWeek,
+		@Param("endOfWeek") LocalDateTime endOfWeek);
 
 }

--- a/linkmind/src/main/java/com/app/toaster/service/category/CategoryService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/category/CategoryService.java
@@ -19,8 +19,10 @@ import com.app.toaster.infrastructure.CategoryRepository;
 import com.app.toaster.infrastructure.TimerRepository;
 import com.app.toaster.infrastructure.ToastRepository;
 import com.app.toaster.infrastructure.UserRepository;
+
 import lombok.RequiredArgsConstructor;
 import lombok.val;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,146 +35,166 @@ import java.util.stream.Stream;
 @Service
 @RequiredArgsConstructor
 public class CategoryService {
-    private final UserRepository userRepository;
-    private final CategoryRepository categoryRepository;
-    private final ToastRepository toastRepository;
+	private final UserRepository userRepository;
+	private final CategoryRepository categoryRepository;
+	private final ToastRepository toastRepository;
 
-    private final static int MAX_CATERGORY_NUMBER = 15;
-    private final TimerRepository timerRepository;
+	private final static int MAX_CATERGORY_NUMBER = 15;
+	private final TimerRepository timerRepository;
 
-    @Transactional
-    public void createCategory(final Long userId, final CreateCategoryDto createCategoryDto){
-        User presentUser = findUser(userId);
+	@Transactional
+	public void createCategory(final Long userId, final CreateCategoryDto createCategoryDto) {
+		User presentUser = findUser(userId);
 
-        // 현재 유저의 최대 우선순위를 가져와서 새로운 우선순위를 설정
-        val maxPriority = categoryRepository.findMaxPriorityByUser(presentUser);
+		// 현재 유저의 최대 우선순위를 가져와서 새로운 우선순위를 설정
+		val maxPriority = categoryRepository.findMaxPriorityByUser(presentUser);
 
-        val categoryNum= categoryRepository.countAllByUser(presentUser);
-        System.out.println(categoryNum);
+		val categoryNum = categoryRepository.countAllByUser(presentUser);
+		System.out.println(categoryNum);
 
-        if(categoryNum >= MAX_CATERGORY_NUMBER){
-            throw new CustomException(Error.BAD_REQUEST_CREATE_CLIP_EXCEPTION, Error.BAD_REQUEST_CREATE_CLIP_EXCEPTION.getMessage());
-        }
+		if (categoryNum >= MAX_CATERGORY_NUMBER) {
+			throw new CustomException(Error.BAD_REQUEST_CREATE_CLIP_EXCEPTION,
+				Error.BAD_REQUEST_CREATE_CLIP_EXCEPTION.getMessage());
+		}
 
-        //카테고리 생성
-        Category newCategory = Category.builder()
-                .title(createCategoryDto.categoryTitle())
-                .user(presentUser)
-                .priority(maxPriority + 1)
-                .build();
+		//카테고리 생성
+		Category newCategory = Category.builder()
+			.title(createCategoryDto.categoryTitle())
+			.user(presentUser)
+			.priority(maxPriority + 1)
+			.build();
 
-        categoryRepository.save(newCategory);
-    }
+		categoryRepository.save(newCategory);
+	}
 
-    @Transactional
-    public void deleteCategory(final ArrayList<Long> deleteCategoryDto){
-        if(deleteCategoryDto.isEmpty()){
-            throw new BadRequestException(Error.BAD_REQUEST_VALIDATION, Error.BAD_REQUEST_VALIDATION.getMessage());
-        }
+	@Transactional
+	public void deleteCategory(final ArrayList<Long> deleteCategoryDto) {
+		if (deleteCategoryDto.isEmpty()) {
+			throw new BadRequestException(Error.BAD_REQUEST_VALIDATION, Error.BAD_REQUEST_VALIDATION.getMessage());
+		}
 
-        toastRepository.updateCategoryIdsToNull(deleteCategoryDto);
+		toastRepository.updateCategoryIdsToNull(deleteCategoryDto);
 
-        for (Long categoryId : deleteCategoryDto) {
-            Category category = categoryRepository.findById(categoryId)
-                    .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_CATEGORY_EXCEPTION, Error.NOT_FOUND_CATEGORY_EXCEPTION.getMessage()));
+		for (Long categoryId : deleteCategoryDto) {
+			Category category = categoryRepository.findById(categoryId)
+				.orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_CATEGORY_EXCEPTION,
+					Error.NOT_FOUND_CATEGORY_EXCEPTION.getMessage()));
 
-            categoryRepository.decreasePriorityNextDeleteCategory(categoryId, category.getPriority(),category.getUser().getUserId());
+			categoryRepository.decreasePriorityNextDeleteCategory(categoryId, category.getPriority(),
+				category.getUser().getUserId());
 
-            Reminder timer = timerRepository.findByCategory_CategoryId(categoryId);
-            if(timer != null)
-                timerRepository.delete(timer);
-            categoryRepository.delete(category);
-        }
+			Reminder timer = timerRepository.findByCategory_CategoryId(categoryId);
+			if (timer != null)
+				timerRepository.delete(timer);
+			categoryRepository.delete(category);
+		}
 
-    }
+	}
 
-    public CategoriesResponse getCategories(final Long userId){
-        User presentUser = findUser(userId);
+	public CategoriesResponse getCategories(final Long userId) {
+		User presentUser = findUser(userId);
 
-        return CategoriesResponse.of(toastRepository.countAllByUser(presentUser),categoryRepository.findAllByUserOrderByPriority(presentUser)
-            .stream()
-            .map(category -> CategoryResponse.builder()
-                .categoryId(category.getCategoryId())
-                .categoryTitle(category.getTitle())
-                .toastNum(toastRepository.getAllByCategory(category).size()).build()
-            ).collect(Collectors.toList()));
+		return CategoriesResponse.of(toastRepository.countAllByUser(presentUser),
+			categoryRepository.findAllByUserOrderByPriority(presentUser)
+				.stream()
+				.map(category -> CategoryResponse.builder()
+					.categoryId(category.getCategoryId())
+					.categoryTitle(category.getTitle())
+					.toastNum(toastRepository.getAllByCategory(category).size()).build()
+				).collect(Collectors.toList()));
 
+	}
 
-    }
+	public GetCategoryResponseDto getCategory(final Long userId, final Long categoryId, final ToastFilter filter) {
+		User presentUser = findUser(userId);
+		if (categoryId == 0) {
+			List<Toast> toastAllList = toastRepository.getAllByUser(presentUser);
+			List<ToastDto> toastListDto = mapToToastDtoList(toastAllList, filter, null);
+			return GetCategoryResponseDto.builder()
+				.allToastNum(countToToast(filter,null,presentUser,true))
+				.toastListDto(toastListDto)
+				.build();
+		}
 
-    public GetCategoryResponseDto getCategory(final Long userId, final Long categoryId, final ToastFilter filter) {
-        User presentUser = findUser(userId);
-        if (categoryId ==0){
-            List<Toast> toastAllList = toastRepository.getAllByUser(presentUser);
-            List<ToastDto> toastListDto = mapToToastDtoList(toastAllList, filter, null);
-            return GetCategoryResponseDto.builder()
-                .allToastNum(toastAllList.size())
-                .toastListDto(toastListDto)
-                .build();
-        }
+		Category category = categoryRepository.findById(categoryId)
+			.orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_CATEGORY_EXCEPTION,
+				Error.NOT_FOUND_CATEGORY_EXCEPTION.getMessage()));
 
-        Category category = categoryRepository.findById(categoryId)
-                .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_CATEGORY_EXCEPTION, Error.NOT_FOUND_CATEGORY_EXCEPTION.getMessage()));
+		category.updateLatestReadTime(LocalDateTime.now());
 
-        category.updateLatestReadTime(LocalDateTime.now());
+		ArrayList<Toast> toasts = toastRepository.getAllByCategory(category);
+		List<ToastDto> toastListDto = mapToToastDtoList(toasts, filter, category);
 
-        ArrayList<Toast> toasts = toastRepository.getAllByCategory(category);
-        List<ToastDto> toastListDto = mapToToastDtoList(toasts, filter, category);
+		return GetCategoryResponseDto.builder()
+			.allToastNum(countToToast(filter,category,presentUser,false))
+			.toastListDto(toastListDto)
+			.build();
+	}
 
-        return GetCategoryResponseDto.builder()
-            .allToastNum(toasts.size())
-            .toastListDto(toastListDto)
-            .build();
-    }
+	//순서 업데이트
+	@Transactional
+	public void editCategoryPriority(ChangeCateoryPriorityDto changeCateoryPriorityDto) {
 
-    //순서 업데이트
-    @Transactional
-    public void editCategoryPriority(ChangeCateoryPriorityDto changeCateoryPriorityDto){
+		val newPriority = changeCateoryPriorityDto.newPriority();
 
-        val newPriority = changeCateoryPriorityDto.newPriority();
+		Category category = categoryRepository.findById(changeCateoryPriorityDto.categoryId())
+			.orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_CATEGORY_EXCEPTION,
+				Error.NOT_FOUND_CATEGORY_EXCEPTION.getMessage()));
 
-        Category category = categoryRepository.findById(changeCateoryPriorityDto.categoryId())
-                .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_CATEGORY_EXCEPTION, Error.NOT_FOUND_CATEGORY_EXCEPTION.getMessage()));
+		int currentPriority = category.getPriority();
+		category.updateCategoryPriority(changeCateoryPriorityDto.newPriority());
 
-        int currentPriority = category.getPriority();
-        category.updateCategoryPriority(changeCateoryPriorityDto.newPriority());
+		if (currentPriority < newPriority)
+			categoryRepository.decreasePriorityByOne(changeCateoryPriorityDto.categoryId(), currentPriority,
+				newPriority, category.getUser().getUserId());
+		else if (currentPriority > newPriority)
+			categoryRepository.increasePriorityByOne(changeCateoryPriorityDto.categoryId(), currentPriority,
+				newPriority, category.getUser().getUserId());
 
-        if(currentPriority < newPriority)
-            categoryRepository.decreasePriorityByOne(changeCateoryPriorityDto.categoryId(), currentPriority, newPriority, category.getUser().getUserId());
-        else if (currentPriority > newPriority)
-            categoryRepository.increasePriorityByOne(changeCateoryPriorityDto.categoryId(), currentPriority, newPriority,category.getUser().getUserId());
+	}
 
+	@Transactional
+	public void editCategoryTitle(ChangeCateoryTitleDto changeCateoryTitleDto) {
 
-    }
+		categoryRepository.updateCategoryTitle(changeCateoryTitleDto.categoryId(), changeCateoryTitleDto.newTitle());
+	}
 
-    @Transactional
-    public void editCategoryTitle(ChangeCateoryTitleDto changeCateoryTitleDto){
+	//해당 유저 탐색
+	private User findUser(Long userId) {
+		return userRepository.findByUserId(userId).orElseThrow(
+			() -> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage())
+		);
+	}
 
-        categoryRepository.updateCategoryTitle(changeCateoryTitleDto.categoryId(), changeCateoryTitleDto.newTitle());
-    }
+	public DuplicatedResponse checkDuplicatedTitle(Long userId, String title) {
+		return DuplicatedResponse.of(categoryRepository.existsCategoriesByUserAndTitle(findUser(userId), title));
 
-    //해당 유저 탐색
-    private User findUser(Long userId){
-        return userRepository.findByUserId(userId).orElseThrow(
-                ()-> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage())
-        );
-    }
+	}
 
-    private List<ToastDto> mapToToastDtoList(List<Toast> toasts, ToastFilter filter, Category category) {
-        Stream<Toast> toastStream = switch (filter) {
-            case ALL -> toasts.stream();
-            case READ -> toasts.stream().filter(Toast::getIsRead);
-            case UNREAD ->toasts.stream().filter(toast -> !toast.getIsRead());
-            default ->
-                    throw new NotFoundException(Error.NOT_FOUND_TOAST_FILTER, Error.NOT_FOUND_TOAST_FILTER.getMessage());
+	private List<ToastDto> mapToToastDtoList(List<Toast> toasts, ToastFilter filter, Category category) {
+		Stream<Toast> toastStream = switch (filter) {
+			case ALL -> toasts.stream();
+			case READ -> toasts.stream().filter(Toast::getIsRead);
+			case UNREAD -> toasts.stream().filter(toast -> !toast.getIsRead());
+			default ->
+				throw new NotFoundException(Error.NOT_FOUND_TOAST_FILTER, Error.NOT_FOUND_TOAST_FILTER.getMessage());
+		};
+
+		return toastStream.map(ToastDto::of).toList();
+	}
+
+	private int countToToast(ToastFilter filter, Category category,User user, boolean isCategoryNull) {
+		if (!isCategoryNull)
+			return switch (filter) {
+				case ALL -> toastRepository.countAllByCategory(category).intValue();
+				case READ -> toastRepository.countAllByCategoryAndIsReadTrue(category).intValue();
+                case UNREAD -> toastRepository.countAllByCategoryAndIsReadFalse(category).intValue();
+			};
+        return switch (filter){
+            case ALL -> toastRepository.countAllByUser(user).intValue();
+            case READ -> toastRepository.countALLByUserAndIsReadTrue(user).intValue();
+            case UNREAD -> toastRepository.countALLByUserAndIsReadFalse(user).intValue();
         };
-
-        return toastStream.map(ToastDto::of).toList();
-    }
-
-    public DuplicatedResponse checkDuplicatedTitle(Long userId, String title){
-        return DuplicatedResponse.of(categoryRepository.existsCategoriesByUserAndTitle(findUser(userId), title));
-
-    }
+	}
 
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #181 

## 📋 구현 기능 명세
- [x] 카테고리 열람 여부에 따른 전체 개수 수정

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
세부 카테고리 뷰에서 전체 개수가 열람여부에 따라 안바뀌는 버그를 수정했습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지
사이드 이펙트 없는지.

- 개발하면서 어떤 점이 궁금했는지
어디 부분이 int로 되어있는지 발견하고 클라쪽에서 바꿀 수 있을 때 한꺼번에 바꿔야할 것 같습니다.

## 📸 결과물 스크린샷
```java
{
    "code": 200,
    "message": "세부 카테고리 조회 성공",
    "data": {
        "allToastNum": 1,
        "toastListDto": [
            {
                "toastId": 38,
                "toastTitle": "네이버",
                "linkUrl": "https://www.naver.com",
                "isRead": false,
                "categoryTitle": "이삭바보",
                "thumbnailUrl": "https://s.pstatic.net/static/www/mobile/edit/2016/0705/mobile_212852414260.png"
            }
        ]
    }
}
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/category
