### PR TITLE
[Fix] : 이주의 링크 일주일마다 랜덤으로 보여주기

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/domain/Link.java
+++ b/linkmind/src/main/java/com/app/toaster/domain/Link.java
@@ -7,6 +7,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,10 +27,27 @@ public class Link {
     @Column(columnDefinition = "TEXT")
     private String thumbnailUrl;
 
+    private LocalDateTime updateAt;
+
+    private boolean thisWeekLink = false;
+
+
     @Builder
     public Link(String title, String linkUrl, String thumbnailUrl) {
         this.title = title;
         this.linkUrl = linkUrl;
         this.thumbnailUrl = thumbnailUrl;
+    }
+
+    public void setWeekLinkFalse(){
+        this.thisWeekLink = false;
+    }
+
+    public void setWeekLinkTrue(){
+        this.thisWeekLink =true;
+    }
+
+    public void setUpdateAtNow(){
+        this.updateAt = LocalDateTime.now();
     }
 }

--- a/linkmind/src/main/java/com/app/toaster/domain/Link.java
+++ b/linkmind/src/main/java/com/app/toaster/domain/Link.java
@@ -43,11 +43,8 @@ public class Link {
         this.thisWeekLink = false;
     }
 
-    public void setWeekLinkTrue(){
-        this.thisWeekLink =true;
-    }
-
-    public void setUpdateAtNow(){
+    public void updateWeekLink(){
         this.updateAt = LocalDateTime.now();
+        this.thisWeekLink =true;
     }
 }

--- a/linkmind/src/main/java/com/app/toaster/domain/RecommendSite.java
+++ b/linkmind/src/main/java/com/app/toaster/domain/RecommendSite.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 
 @Getter
 @Entity
@@ -16,15 +18,15 @@ public class RecommendSite {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long siteId;
 
-    String siteTitle;
+    private String siteTitle;
 
-    String siteUrl;
+    @Column(columnDefinition = "TEXT")
+    private String siteUrl;
 
-    String siteImg;
+    private String siteImg;
 
     @Enumerated(EnumType.STRING)
-    Topic siteSub;
-
+    private Topic siteSub;
 
     @Builder
     public RecommendSite(String siteTitle, String siteUrl, String siteImg, Topic siteSub) {

--- a/linkmind/src/main/java/com/app/toaster/external/client/fcm/FCMController.java
+++ b/linkmind/src/main/java/com/app/toaster/external/client/fcm/FCMController.java
@@ -39,12 +39,12 @@ public class FCMController {
     /**
      * 새로운 질문이 도착했음을 알리는 푸시 알림 활성화 API
      */
-    @PostMapping("/qna")
-    @ResponseStatus(HttpStatus.OK)
-    public ApiResponse sendTopicScheduledTest(@RequestBody FCMPushRequestDto request) {
-        sqsProducer.sendMessage(request);
-        return ApiResponse.success(Success.PUSH_ALARM_PERIODIC_SUCCESS);
-    }
+//    @PostMapping("/qna")
+//    @ResponseStatus(HttpStatus.OK)
+//    public ApiResponse sendTopicScheduledTest(@RequestBody FCMPushRequestDto request) {
+//        sqsProducer.sendMessage(request);
+//        return ApiResponse.success(Success.PUSH_ALARM_PERIODIC_SUCCESS);
+//    }
 
     @DeleteMapping("/clear")
     @ResponseStatus(HttpStatus.OK)

--- a/linkmind/src/main/java/com/app/toaster/external/client/fcm/FCMScheduler.java
+++ b/linkmind/src/main/java/com/app/toaster/external/client/fcm/FCMScheduler.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -39,5 +40,6 @@ public class FCMScheduler {
 
         return "오늘의 토스터를 구워 전달했어요!!!";
     }
+
 
 }

--- a/linkmind/src/main/java/com/app/toaster/external/client/sqs/SqsProducer.java
+++ b/linkmind/src/main/java/com/app/toaster/external/client/sqs/SqsProducer.java
@@ -23,7 +23,7 @@ public class SqsProducer {
     private static final String SQS_QUEUE_REQUEST_LOG_MESSAGE = "====> [SQS Queue Request] : %s ";
 
 
-    public void sendMessage(FCMPushRequestDto requestDto,String timerId) {
+    public void sendMessage(FCMPushRequestDto requestDto, String timerId) {
         System.out.println("Sender: " + requestDto.getBody());
         template.send(to -> {
             try {

--- a/linkmind/src/main/java/com/app/toaster/infrastructure/LinkRepository.java
+++ b/linkmind/src/main/java/com/app/toaster/infrastructure/LinkRepository.java
@@ -1,10 +1,13 @@
 package com.app.toaster.infrastructure;
 
+import com.app.toaster.domain.Category;
 import com.app.toaster.domain.Link;
+import com.app.toaster.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Repository
@@ -12,5 +15,8 @@ public interface LinkRepository extends JpaRepository<Link, Long> {
 
     @Query("SELECT e FROM Link e ORDER BY FUNCTION('RAND') FETCH FIRST 3 ROWS ONLY")
     List<Link> findRandom3Links();
+
+    List<Link> findAllByThisWeekLinkIsTrue();
+
 
 }

--- a/linkmind/src/main/java/com/app/toaster/service/link/LinkService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/link/LinkService.java
@@ -1,22 +1,42 @@
 package com.app.toaster.service.link;
 
 import com.app.toaster.controller.response.toast.WeekLinkDto;
+import com.app.toaster.domain.Link;
 import com.app.toaster.infrastructure.LinkRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class LinkService {
 
     private final LinkRepository linkRepository;
+
+    @Transactional
     public List<WeekLinkDto> getWeekLinks(){
 
-        return linkRepository.findRandom3Links().stream().map(WeekLinkDto::of).toList();
+        List<Link> lists = linkRepository.findAllByThisWeekLinkIsTrue();
+
+        long days = Duration.between(lists.get(0).getUpdateAt(), LocalDateTime.now()).toDays();
+
+        if(days>7){
+            lists.forEach(Link::setWeekLinkFalse);
+            lists = linkRepository.findRandom3Links().stream()
+                    .peek(Link::setUpdateAtNow)
+                    .peek(Link::setWeekLinkTrue)
+                    .toList();
+        }
+
+
+        return lists.stream().map(WeekLinkDto::of).toList();
     }
-
-
 
 }

--- a/linkmind/src/main/java/com/app/toaster/service/link/LinkService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/link/LinkService.java
@@ -30,8 +30,7 @@ public class LinkService {
         if(days>7){
             lists.forEach(Link::setWeekLinkFalse);
             lists = linkRepository.findRandom3Links().stream()
-                    .peek(Link::setUpdateAtNow)
-                    .peek(Link::setWeekLinkTrue)
+                    .peek(Link::updateWeekLink)
                     .toList();
         }
 

--- a/linkmind/src/main/java/com/app/toaster/service/recommendSite/RecommendSiteService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/recommendSite/RecommendSiteService.java
@@ -6,6 +6,7 @@ import com.app.toaster.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -19,4 +20,5 @@ public class RecommendSiteService {
 
         return recommedSiteRepository.findAll().subList(0, Math.min(9, recommedSiteRepository.findAll().size()));
     }
+
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #198 

## 📋 구현 기능 명세
- [x] 이주의 링크 일주일마다 랜덤으로 보여주기

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
매주 이주의 링크를 바꿔야함 -> 이주의 링크(thisWeekLink가 true)인 updateAt이 일주일이 지나면 false로 바꾸고 새로운 3개를 뽑아서 이주의 링크로 등록 후 updateAt을 다시 수정 해주었습니다. 

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
<img width="1149" alt="스크린샷 2024-01-19 오전 6 29 39" src="https://github.com/Link-MIND/TOASTER-Server/assets/92644651/c5601587-b7c7-47d4-868e-145b578d827f">

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/toast/week
