### PR TITLE
[Feature/#200] 카톡 서버 회원탈퇴 구현

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/service/auth/AuthService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/AuthService.java
@@ -136,9 +136,10 @@ public class AuthService {
 	public void withdraw(Long userId) {
 		User user = userRepository.findByUserId(userId).orElseThrow(
 			()->new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
-		// if (user.getSocialType() == SocialType.KAKAO){
-		// 	kakaoSignInService.withdrawKakao(accessToken);
-		// }
+		if (user.getSocialType() == SocialType.KAKAO){
+			String deleteSocialId = kakaoSignInService.withdrawKakao(user.getSocialId());
+			System.out.println(deleteSocialId);
+		}
 		try {
 			toastService.deleteAllToast(user);
 		}catch (IOException e){


### PR DESCRIPTION
## 🚩 관련 이슈
- close #200 

## 📋 구현 기능 명세
- [x] 카톡 서버 회원탈퇴 구현

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
처음에 인가코드를 다시 받아 회원탈퇴 로직을 만들었다보니 로그인 뷰를 한번 더 띄우는 상황이 일어나서 어드민키를 이용해 서버측에서 회원탈퇴하는 방식으로 구현했습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지
사이드 이펙트로 다른 부분이 오류가 생겼는지

- 개발하면서 어떤 점이 궁금했는지
머지할 때 도커가 괜찮을지

## 📸 결과물 스크린샷
```java
{
    "code": 200,
    "message": "회원 탈퇴가 정상적으로 이루어졌습니다.",
    "data": null
}
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/auth/withdraw
