### PR TITLE
[Fix/#203] 검색 시 한글 자음 모음 허용

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/controller/valid/TitleValidator.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/valid/TitleValidator.java
@@ -45,7 +45,7 @@ public class TitleValidator implements ConstraintValidator<TitleValid, String> {
 			return false;
 		}
 
-		if(!title.matches("^[\\S][가-힣a-zA-Z0-9\\s]{0,20}$")){
+		if(!title.matches("^[\\S][가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9\\s]{0,20}$")){
 			context.buildConstraintViolationWithTemplate("특수 문자로는 검색할 수 없어요.")
 				.addConstraintViolation();
 			return false;


### PR DESCRIPTION
## 🚩 관련 이슈
- close #203 

## 📋 구현 기능 명세
- [x] 검색 시 한글 자음 모음 허용

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
검색 시 한글 자음 모음도 허용되어야하는데 qa중 버그가 발견되어 수정합니다.

- 어떤 부분에 리뷰어가 집중해야 하는지
더 찾아야할 것이 있는지

- 개발하면서 어떤 점이 궁금했는지
"ㅎ" 이렇게 한 글자 넣었을 때는 왜 통과가 되었는지 잘 모르겠습니다 ㅜ
## 📸 결과물 스크린샷
```java
{
    "code": 200,
    "message": "검색 성공",
    "data": {
        "keyword": "ㅏ",
        "toasts": [],
        "categories": [
            {
                "categoryId": 244,
                "title": "ㅏ아",
                "toastNum": 0
            }
        ]
    }
}
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/main/search
