### PR TITLE
[Fix] 타이머 요일 정렬해서 저장

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
@@ -70,6 +70,8 @@ public class TimerService {
             throw new CustomException(Error.UNPROCESSABLE_CREATE_TIMER_EXCEPTION, Error.UNPROCESSABLE_CREATE_TIMER_EXCEPTION.getMessage());
         }
 
+        createTimerRequestDto.remindDates().sort(Comparator.naturalOrder());
+
         Reminder reminder = Reminder.builder()
                 .user(presentUser)
                 .category(category)
@@ -107,6 +109,7 @@ public class TimerService {
         if (!presentUser.equals(reminder.getUser())){
             throw new CustomException(Error.INVALID_USER_ACCESS, Error.INVALID_USER_ACCESS.getMessage());
         }
+        updateTimerDateTimeDto.remindDates().sort(Comparator.naturalOrder());
         reminder.updateRemindDates(updateTimerDateTimeDto.remindDates());
         reminder.updateRemindTime(updateTimerDateTimeDto.remindTime());
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #206 

## 📋 구현 기능 명세
- [x] 타이머 요일 정렬해서 저장

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
타이머 조회할때 요일이 정렬되지않으면 정렬되어 나타나서 정렬하여 저장하는 로직으로 변경했습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
```java
결과 예시 사진 첨부
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/timer
- baseurl/datetime/{timerId}
