### PR TITLE
[Fix] 완료된 타이머 계산 로직 변경

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/timer/TimerService.java
@@ -184,6 +184,10 @@ public class TimerService {
                 .sorted(Comparator.comparing(CompletedTimerDto::remindTime))
                 .collect(Collectors.toList());
 
+        for(Reminder reminder : reminders){
+            System.out.println(reminder.getId());
+            System.out.println(isCompletedTimer(reminder));
+        }
 
         List<WaitingTimerDto> waitingTimerList = reminders.stream()
                 .filter(reminder -> !isCompletedTimer(reminder))
@@ -213,12 +217,15 @@ public class TimerService {
         // 현재 시간
         LocalDateTime now = LocalDateTime.now();
 
-        LocalTime futureDateTime = LocalTime.from(now.plusHours(1));
-        LocalTime pastDateTime = LocalTime.from(now.minusHours(1));
+        LocalDateTime pastDateTime = now.minusHours(1);
+        LocalDateTime futureDateTime = now.plusHours(1);
+
+//        System.out.println(pastDateTime + ", " + now + ", " + futureDateTime);
 
         if (reminder.getRemindDates().contains(now.getDayOfWeek().getValue())) {
-            LocalTime reminderTime = reminder.getRemindTime();
-            return !reminderTime.isBefore(pastDateTime) && !reminderTime.isAfter(futureDateTime) && reminder.getIsAlarm();
+            LocalDateTime reminderDateTime = LocalDateTime.of(now.toLocalDate(), reminder.getRemindTime());
+
+            return !reminderDateTime.isBefore(pastDateTime) && !reminderDateTime.isAfter(futureDateTime) && reminder.getIsAlarm();
         }
 
         return false;


### PR DESCRIPTION
## 🚩 관련 이슈
- close #210 

## 📋 구현 기능 명세
- [x] 완료된 타이머 계산 로직 변경

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
완료된 타이머 1시간이내 계산할때 LocalTime으로 계산해서 12시 넘어가면 계산이 안되는 오류가 있었습니다.
LocalDateTime을 사용하여 날짜까지 고려하여 1시간이내를 계산하였습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
<img width="887" alt="스크린샷 2024-01-19 오후 11 22 44" src="https://github.com/Link-MIND/TOASTER-Server/assets/92644651/cc04533a-8dd7-49d7-94c7-e297ca37e38c">


## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/timer/main
