### PR TITLE
[#222] fix: 카톡 프사가 없으면 회원가입안되는 치명적 이슈..

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/service/auth/kakao/KakaoSignInService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/kakao/KakaoSignInService.java
@@ -36,8 +36,9 @@ public class KakaoSignInService {
 		ResponseEntity<Object> responseData = requestKakaoServer(accessToken, Strategy.LOGIN);
 		ObjectMapper objectMapper = new ObjectMapper();
 		HashMap profileResponse = (HashMap)objectMapper.convertValue( responseData.getBody(),Map.class).get("properties");
-		return LoginResult.of(objectMapper.convertValue(responseData.getBody(), Map.class).get("id").toString(), profileResponse==null?null:profileResponse.get("profile_image").toString(),
-			profileResponse==null?null:profileResponse.get("nickname").toString()); //프로필 이미지 허용 x시 null로 넘기기.
+		return LoginResult.of(objectMapper.convertValue(responseData.getBody(), Map.class).get("id").toString(),
+			profileResponse==null||profileResponse.get("profile_image")==null?null:profileResponse.get("profile_image").toString(),
+			profileResponse==null||profileResponse.get("nickname")==null?null:profileResponse.get("nickname").toString()); //프로필 이미지 허용 x시 null로 넘기기.
 	}
 	// 인가코드 나중에 서버에서 한번에 처리 하는 방식으로 변경. ux 이슈
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #222 

## 📋 구현 기능 명세
- [x] 카톡 프사를 허용해놓고 카톡 프사가 비어있으면 회원가입이 안되는 치명적인 이슈가 있었습니다..

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
가현이가 회원가입이 안되는 이슈가 있길래 버그를 해결했습니다..

- 어떤 부분에 리뷰어가 집중해야 하는지
호딱 리뷰해주실 수 있을까요 ㅠㅠ

- 개발하면서 어떤 점이 궁금했는지
닉네임도 비슷하게 오류가 있을 수도 있나해서 일단 안전하게 과잉진압해봤습니다.

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/auth
