### PR TITLE
[Fix/#233] iframe에서 brunch 케이스 해결

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/controller/ToastController.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/ToastController.java
@@ -76,7 +76,7 @@ public class ToastController {
 	public ApiResponse deleteToast(		//나중에 softDelete로 변경
 		@UserId Long userId,
 		@RequestParam Long toastId
-	) throws IOException {
+	) {
 		toastService.deleteToast(userId, toastId);
 		return ApiResponse.success(Success.DELETE_TOAST_SUCCESS);
 	}

--- a/linkmind/src/main/java/com/app/toaster/service/toast/ToastService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/toast/ToastService.java
@@ -105,7 +105,7 @@ public class ToastService {
 	}
 
 	@Transactional
-	public void deleteToast(Long userId, Long toastId) throws IOException {
+	public void deleteToast(Long userId, Long toastId) {
 		User presentUser =  userRepository.findByUserId(userId).orElseThrow(
 			()-> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage())
 		);

--- a/linkmind/src/test/java/com/app/toaster/base/MockUserIdResolver.java
+++ b/linkmind/src/test/java/com/app/toaster/base/MockUserIdResolver.java
@@ -1,0 +1,31 @@
+package com.app.toaster.base;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.app.toaster.config.UserId;
+import com.app.toaster.config.UserIdResolver;
+import com.app.toaster.config.jwt.JwtService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.constraints.NotNull;
+
+
+public class MockUserIdResolver extends UserIdResolver {
+
+	public MockUserIdResolver(JwtService jwtService) {
+		super(jwtService);
+	}
+
+	@Override
+	public Object resolveArgument(@NotNull MethodParameter parameter, ModelAndViewContainer modelAndViewContainer, @NotNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+		return 125L;
+	}
+
+}

--- a/linkmind/src/test/java/com/app/toaster/base/WithMockCustomUser.java
+++ b/linkmind/src/test/java/com/app/toaster/base/WithMockCustomUser.java
@@ -1,0 +1,11 @@
+package com.app.toaster.base;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface WithMockCustomUser {
+}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #233 

## 📋 구현 기능 명세
- [x] test 코드 작성, 불필요 exception 제거
- [x] test 완료 후 메인코드에 올리고 로컬에서 테스트 진행

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
open graph 데이터를 가져올 때 브런치의 경우 image url이 가져와지는데 fname 태그 안에 들어있는 상태로 들어와서 빈 이미지가 저장되는 버그가 있어서 수정해야했습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지
로직 변경이 원래 로직들을 건드리지는 않았을지 확인이 필요할 것 같고, 다른 링크 중에 저장안되는 케이스가 있다면 추가해야할 것 같습니다.

- 개발하면서 어떤 점이 궁금했는지
일단 임시로 정규식으로 때려넣긴했는데.. jsoup식으로 조금 리팩토링 할 수 있을 것 같지만 다음 브랜치 파서 해결해보도록 하겠습니다. 코드가 이쁘지 않은 것 같기도 하고 변수명 다들 너무 헷갈리게 지은 것 같아 고민을 좀 더 해보고 수정하겠습니다.

## 📸 결과물 스크린샷
- Before
<img width="541" alt="스크린샷 2024-03-18 오전 2 03 14" src="https://github.com/Link-MIND/TOASTER-Server/assets/49307946/8a28e00e-0b0d-466d-bb94-7e4aa84d2185">

- After
<img width="556" alt="스크린샷 2024-03-18 오전 2 04 30" src="https://github.com/Link-MIND/TOASTER-Server/assets/49307946/ec703577-71d8-4e19-8072-c03aa55f1532">


## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- toast/save
