### PR TITLE
[Feature/#235] 온보딩에서의 토큰 유효성 검사 API 작성

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/common/advice/ControllerExceptionAdvice.java
+++ b/linkmind/src/main/java/com/app/toaster/common/advice/ControllerExceptionAdvice.java
@@ -15,6 +15,7 @@ import org.springframework.validation.ObjectError;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -111,6 +112,14 @@ public class ControllerExceptionAdvice {
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(UnknownHostException.class)
 	protected ResponseEntity<ApiResponse> UnknownHostException(final UnknownHostException e) {
+		Sentry.captureException(e);
+		return ResponseEntity.status(Error.BAD_REQUEST_VALIDATION.getErrorCode())
+			.body(ApiResponse.error(Error.BAD_REQUEST_VALIDATION, Error.BAD_REQUEST_VALIDATION.getMessage()));
+	}
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(MissingRequestHeaderException.class)
+	protected ResponseEntity<ApiResponse> MissingRequestHeaderException(final MissingRequestHeaderException e){
 		Sentry.captureException(e);
 		return ResponseEntity.status(Error.BAD_REQUEST_VALIDATION.getErrorCode())
 			.body(ApiResponse.error(Error.BAD_REQUEST_VALIDATION, Error.BAD_REQUEST_VALIDATION.getMessage()));

--- a/linkmind/src/main/java/com/app/toaster/controller/AuthController.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/AuthController.java
@@ -58,9 +58,9 @@ public class AuthController {
 		return ApiResponse.success(Success.DELETE_USER_SUCCESS);
 	}
 
-	@PostMapping("/token-vaild")
+	@PostMapping("/token/health")
 	@ResponseStatus(HttpStatus.OK)
-	public ApiResponse<TokenHealthDto> checkHealthOfToken(@RequestHeader String refreshToken) {
-		return ApiResponse.success(Success.TOKEN_HEALTH_CHECKED_SUCCESS, authService.checkHealthOfToken(refreshToken));
+	public ApiResponse<TokenHealthDto> checkHealthOfToken(@RequestHeader String token) {
+		return ApiResponse.success(Success.TOKEN_HEALTH_CHECKED_SUCCESS, authService.checkHealthOfToken(token));
 	}
 }

--- a/linkmind/src/main/java/com/app/toaster/controller/AuthController.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/AuthController.java
@@ -16,6 +16,7 @@ import com.app.toaster.common.dto.ApiResponse;
 import com.app.toaster.config.UserId;
 import com.app.toaster.controller.request.auth.SignInRequestDto;
 import com.app.toaster.controller.response.auth.SignInResponseDto;
+import com.app.toaster.controller.response.auth.TokenHealthDto;
 import com.app.toaster.controller.response.auth.TokenResponseDto;
 import com.app.toaster.exception.Success;
 import com.app.toaster.service.auth.AuthService;
@@ -55,5 +56,11 @@ public class AuthController {
 	public ApiResponse withdraw(@UserId Long userId) {
 		authService.withdraw(userId);
 		return ApiResponse.success(Success.DELETE_USER_SUCCESS);
+	}
+
+	@PostMapping("/token-vaild")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<TokenHealthDto> checkHealthOfToken(@RequestHeader String refreshToken) {
+		return ApiResponse.success(Success.TOKEN_HEALTH_CHECKED_SUCCESS, authService.checkHealthOfToken(refreshToken));
 	}
 }

--- a/linkmind/src/main/java/com/app/toaster/controller/response/auth/TokenHealthDto.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/response/auth/TokenHealthDto.java
@@ -1,0 +1,5 @@
+package com.app.toaster.controller.response.auth;
+
+public record TokenHealthDto(boolean tokenHealth) {
+	public static TokenHealthDto of(boolean tokenHealth){return new TokenHealthDto(tokenHealth);}
+}

--- a/linkmind/src/main/java/com/app/toaster/exception/Success.java
+++ b/linkmind/src/main/java/com/app/toaster/exception/Success.java
@@ -33,6 +33,7 @@ public enum Success {
 
   	LOGIN_SUCCESS(HttpStatus.OK, "로그인 성공"),
 	RE_ISSUE_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급 성공"),
+	TOKEN_HEALTH_CHECKED_SUCCESS(HttpStatus.OK, "토큰 헬스체크 성공"),
 	SIGNOUT_SUCCESS(HttpStatus.OK, "로그아웃 성공"),
 	DELETE_USER_SUCCESS(HttpStatus.OK, "회원 탈퇴가 정상적으로 이루어졌습니다."),
 	DELETE_TOAST_SUCCESS(HttpStatus.OK, "토스트 삭제 성공"),

--- a/linkmind/src/main/java/com/app/toaster/service/auth/AuthService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/AuthService.java
@@ -7,9 +7,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
+import com.app.toaster.common.dto.ApiResponse;
 import com.app.toaster.config.jwt.JwtService;
 import com.app.toaster.controller.request.auth.SignInRequestDto;
 import com.app.toaster.controller.response.auth.SignInResponseDto;
+import com.app.toaster.controller.response.auth.TokenHealthDto;
 import com.app.toaster.controller.response.auth.TokenResponseDto;
 import com.app.toaster.domain.SocialType;
 import com.app.toaster.domain.User;
@@ -154,6 +156,11 @@ public class AuthService {
 		if (res!=1){
 			throw new UnprocessableEntityException(Error.UNPROCESSABLE_ENTITY_DELETE_EXCEPTION, Error.UNPROCESSABLE_ENTITY_DELETE_EXCEPTION.getMessage());
 		}
+	}
+
+	@Transactional(readOnly = true)
+	public TokenHealthDto checkHealthOfToken(String refreshToken){
+		return TokenHealthDto.of(jwtService.verifyToken(refreshToken));
 	}
 
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #235 

## 📋 구현 기능 명세
- [x] 토큰 유효성 기간 API 작성

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
포스트맨 억까인지 어제 테스트했던 url로 요청을 다시 보냈더니 이해 못하길래 /로 쪼개서 보냈고, accessToken에 대해서도 살아있는지 죽었는지 판단하는 API가 있었으면 좋겠다고 하여 작성했습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지
뭔가 더 좋은 온보딩에서의 API 요청 방식이 있지않을까 생각되긴하지만 요청 사항이기에 만들고 나중에 좋은 방법으로 갈아끼우면 되지않을까싶습니다.

- 개발하면서 어떤 점이 궁금했는지
auth/token-valid 느낌으로 url을 작성했는데 왜 포스트맨에서 안읽혔던 건지 모르겠네요.. 그리고 다른 사이드 이펙트가 있을지 모르겠습니다.
## 📸 결과물 스크린샷
```java
{
    "code": 200,
    "message": "토큰 헬스체크 성공",
    "data": {
        "tokenHealth": true
    }
}
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- auth/token/health
