### PR TITLE
[Feature/#240] 팝업 관련 api 구현

### DIFF
--- a/linkmind/build.gradle
+++ b/linkmind/build.gradle
@@ -34,17 +34,7 @@ dependencies {
 	implementation 'mysql:mysql-connector-java:8.0.32'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-<<<<<<< HEAD
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-	implementation 'io.sentry:sentry-spring-boot-starter:5.7.0'
-	//JWT
-	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
-	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
-	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
-=======
     runtimeOnly 'com.h2database:h2'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -60,30 +50,20 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
->>>>>>> e290d55 (#239 fix: queryDSL 의존성 제거 및 관련 내용들 주석처리)
 
 
 	// FCM
 	implementation 'com.google.firebase:firebase-admin:9.1.1'
 	implementation 'com.squareup.okhttp3:okhttp:4.10.0'  // Firebase 서버로 푸시 메시지 전송 시 필요
 
-<<<<<<< HEAD
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-	//Query DSL
-	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
-	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-=======
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-//
-//    //Query DSL
+
+//Query DSL
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
     annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
->>>>>>> e290d55 (#239 fix: queryDSL 의존성 제거 및 관련 내용들 주석처리)
 
 	// S3 AWS
 	implementation("software.amazon.awssdk:bom:2.21.0")
@@ -100,12 +80,6 @@ dependencies {
 	implementation 'io.sentry:sentry-spring-boot-starter:5.7.0'
 
 }
-<<<<<<< HEAD
-
-
-tasks.named('test') {
-	useJUnitPlatform()
-=======
 //sourceSets {
 //	main {
 //		java {
@@ -119,7 +93,6 @@ tasks.named('test') {
 tasks.named('test') {
     useJUnitPlatform()
 //    finalizedBy 'jacocoTestReport' // test가 끝나면 jacocoTestReport 동작
->>>>>>> e290d55 (#239 fix: queryDSL 의존성 제거 및 관련 내용들 주석처리)
 }
 //// jacoco report 설정
 //jacocoTestReport {

--- a/linkmind/build.gradle
+++ b/linkmind/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	implementation 'mysql:mysql-connector-java:8.0.32'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+<<<<<<< HEAD
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -43,12 +44,30 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+=======
+    runtimeOnly 'com.h2database:h2'
+
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation group: 'com.h2database', name: 'h2', version: '2.2.224'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    implementation 'io.sentry:sentry-spring-boot-starter:5.7.0'
+    //JWT
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+>>>>>>> e290d55 (#239 fix: queryDSL 의존성 제거 및 관련 내용들 주석처리)
 
 
 	// FCM
 	implementation 'com.google.firebase:firebase-admin:9.1.1'
 	implementation 'com.squareup.okhttp3:okhttp:4.10.0'  // Firebase 서버로 푸시 메시지 전송 시 필요
 
+<<<<<<< HEAD
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	//Query DSL
@@ -56,6 +75,15 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+=======
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+//
+//    //Query DSL
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+>>>>>>> e290d55 (#239 fix: queryDSL 의존성 제거 및 관련 내용들 주석처리)
 
 	// S3 AWS
 	implementation("software.amazon.awssdk:bom:2.21.0")
@@ -72,8 +100,86 @@ dependencies {
 	implementation 'io.sentry:sentry-spring-boot-starter:5.7.0'
 
 }
+<<<<<<< HEAD
 
 
 tasks.named('test') {
 	useJUnitPlatform()
+=======
+//sourceSets {
+//	main {
+//		java {
+//			srcDirs = ["$projectDir/src/main/java", "$projectDir/build/generated"]
+//		}
+//	}
+//}
+//compileJava {	options.compilerArgs << '-parameters'}
+
+
+tasks.named('test') {
+    useJUnitPlatform()
+//    finalizedBy 'jacocoTestReport' // test가 끝나면 jacocoTestReport 동작
+>>>>>>> e290d55 (#239 fix: queryDSL 의존성 제거 및 관련 내용들 주석처리)
 }
+//// jacoco report 설정
+//jacocoTestReport {
+//    reports {
+//        // html로 report 생성하기
+//        // 빌드경로/jacoco/report.html 폴더 내부로 경로 설정
+//        html.destination file("$jacoco/report.html")
+//    }
+//
+//    // jacocoTestReport가 끝나면 jacocoTestCoverageVerification 동작
+//    finalizedBy 'jacocoTestCoverageVerification'
+//}
+//
+//// jacoco 커버리지 검증 설정
+//jacocoTestCoverageVerification {
+//    violationRules {
+//        rule {
+//            enabled = true // 커버리지 적용 여부
+//            element = 'CLASS' // 커버리지 적용 단위
+//
+//            // 라인 커버리지 설정
+//            // 적용 대상 전체 소스 코드들을 한줄 한줄 따졌을 때 테스트 코드가 작성되어 있는 줄의 빈도
+//            // 테스트 코드가 작성되어 있는 비율이 90% 이상이어야 함
+//            limit {
+//                counter = 'LINE'
+//                value = 'COVEREDRATIO'
+//                minimum = 0.10
+//            }
+//
+//            // 브랜치 커버리지 설정
+//            // if-else 등을 활용하여 발생되는 분기들 중 테스트 코드가 작성되어 있는 빈도
+//            // 테스트 코드가 작성되어 있는 비율이 90% 이상이어야 함
+//            limit {
+//                counter = 'BRANCH'
+//                value = 'COVEREDRATIO'
+//                minimum = 0.00
+//            }
+//
+//            // 라인 최대 갯수 설정
+//            // 빈 줄을 제외하고 하나의 자바 파일에서 작성될 수 있는 최대 라인 갯수
+//            // 한 파일에 최대 500줄까지 작성되어야 함
+//            limit {
+//                counter = 'LINE'
+//                value = 'TOTALCOUNT'
+//                maximum = 500
+//            }
+//            // 커버리지 체크를 제외할 클래스들
+//            excludes = [
+//                    //      '*.test.*',
+//                    '*.common.*',
+//                    '*.config.*',
+//                    '*.controller.*',
+//                    '*.domain.*',
+//                    '*.exception.*',
+//                    '*.external.*',
+//                    '*.infrastructure.*',
+//                    '*.auth.*',
+//                    '*.service.*'
+//
+//            ]
+//        }
+//    }
+//}

--- a/linkmind/src/main/java/com/app/toaster/config/JpaQueryFactoryConfig.java
+++ b/linkmind/src/main/java/com/app/toaster/config/JpaQueryFactoryConfig.java
@@ -1,17 +1,17 @@
-package com.app.toaster.config;
-
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
-import com.querydsl.jpa.impl.JPAQueryFactory;
-
-import jakarta.persistence.EntityManager;
-
-@Configuration
-public class JpaQueryFactoryConfig {
-
-	@Bean
-	JPAQueryFactory jpaQueryFactory(EntityManager em) {
-		return new JPAQueryFactory(em);
-	}
-}
+// package com.app.toaster.config;
+//
+// import org.springframework.context.annotation.Bean;
+// import org.springframework.context.annotation.Configuration;
+//
+// import com.querydsl.jpa.impl.JPAQueryFactory;
+//
+// import jakarta.persistence.EntityManager;
+//
+// @Configuration
+// public class JpaQueryFactoryConfig {
+//
+// 	@Bean
+// 	JPAQueryFactory jpaQueryFactory(EntityManager em) {
+// 		return new JPAQueryFactory(em);
+// 	}
+// }

--- a/linkmind/src/main/java/com/app/toaster/exception/Error.java
+++ b/linkmind/src/main/java/com/app/toaster/exception/Error.java
@@ -20,6 +20,7 @@ public enum Error {
 	NOT_FOUND_IMAGE_EXCEPTION(HttpStatus.NOT_FOUND, "s3 서비스에서 이미지를 찾을 수 없습니다."),
 	NOT_FOUND_TOAST_FILTER(HttpStatus.NOT_FOUND, "유효하지 않은 필터입니다."),
 	NOT_FOUND_TIMER(HttpStatus.NOT_FOUND, "찾을 수 없는 타이머입니다."),
+	NOT_FOUND_POPUP_EXCEPTION(HttpStatus.NOT_FOUND, "유효하지 않은 팝업입니다."),
 
 	/**
 	 * 400 BAD REQUEST EXCEPTION

--- a/linkmind/src/main/java/com/app/toaster/exception/Success.java
+++ b/linkmind/src/main/java/com/app/toaster/exception/Success.java
@@ -24,6 +24,7 @@ public enum Success {
 	GET_LINKS_SUCCESS(HttpStatus.OK, "이주의 링크 조회 성공"),
 	GET_SITES_SUCCESS(HttpStatus.OK, "추천 사이트 조회 성공"),
 	GET_SETTINGS_SUCCESS(HttpStatus.OK, "설정 페이지 조회 성공"),
+	GET_POPUP_SUCCESS(HttpStatus.OK, "팝업 정보 조회 성공"),
 
 	GET_CATEORIES_SUCCESS(HttpStatus.OK, "전체 카테고리 조회 성공"),
 	GET_CATEORY_SUCCESS(HttpStatus.OK, "세부 카테고리 조회 성공"),
@@ -52,6 +53,7 @@ public enum Success {
 	PUSH_ALARM_PERIODIC_SUCCESS(HttpStatus.OK, "푸시알림 활성에 성공했습니다."),
 	PUSH_ALARM_SUCCESS(HttpStatus.OK, "푸시알림 전송에 성공했습니다."),
 	CLEAR_SCHEDULED_TASKS_SUCCESS(HttpStatus.OK, "스케줄러에서 예약된 작업을 제거했습니다."),
+	UPDATE_POPUP_SUCCESS(HttpStatus.OK, "팝업 데이터 수정 성공"),
 
 
 	/**

--- a/linkmind/src/main/java/com/app/toaster/infrastructure/querydsl/CustomToastRepository.java
+++ b/linkmind/src/main/java/com/app/toaster/infrastructure/querydsl/CustomToastRepository.java
@@ -1,0 +1,154 @@
+// package com.app.toaster.infrastructure.querydsl;
+//
+// import static com.app.toaster.domain.QToast.*;
+// import static com.app.toaster.domain.QUser.*;
+//
+// import java.time.LocalDateTime;
+// import java.util.ArrayList;
+// import java.util.List;
+// import org.springframework.data.jpa.repository.Modifying;
+// import org.springframework.data.jpa.repository.Query;
+// import org.springframework.data.repository.query.Param;
+// import org.springframework.stereotype.Repository;
+//
+// import com.app.toaster.domain.Category;
+// import com.app.toaster.domain.QToast;
+// import com.app.toaster.domain.QUser;
+// import com.app.toaster.domain.Toast;
+// import com.app.toaster.domain.User;
+// import com.querydsl.core.types.Path;
+// import com.querydsl.core.types.dsl.BooleanExpression;
+// import com.querydsl.jpa.impl.JPAQueryFactory;
+//
+// import jakarta.persistence.EntityManager;
+// import lombok.RequiredArgsConstructor;
+//
+// @Repository
+// @RequiredArgsConstructor
+// public class CustomToastRepository {
+// 	private final JPAQueryFactory queryFactory;
+// 	// private final EntityManager em;
+// 	public List<Toast> getAllByCategory(Category category){
+// 		return queryFactory.select(toast)
+// 			.from(toast)
+// 			.where(eqCategoryId(category.getCategoryId()))
+// 			.fetch();
+// 	}
+//
+// 	private BooleanExpression eqCategoryId(Long id){
+// 		if (id == null){
+// 			return null;
+// 		}
+// 		return toast.category.categoryId.eq(id);
+// 	}
+//
+// 	ArrayList<Toast> findByIsReadAndCategory(Boolean isRead, Category category){
+// 		return null;
+// 	};
+//
+// 	ArrayList<Toast> getAllByUser(User user){
+// 		return null;
+// 	}
+//
+// 	List<Toast> getAllByUserOrderByCreatedAtDesc(User user){
+// 		return null;
+// 	}
+//
+//
+// 	ArrayList<Toast> getAllByUserAndIsReadIsTrue(User user){
+// 		return null;
+// 	}
+//
+//
+// 	// @Modifying
+// 	// @Query("UPDATE Toast t SET t.category = null WHERE t.category.categoryId IN :categoryIds")
+// 	// void updateCategoryIdsToNull(@Param("categoryIds") List<Long> categoryIds){
+// 	// }
+//
+// 	//querydsl의 수정은 bulkupdate라 영속성컨텍스트를 안거치기 때문에 무조건 flush,clear해주자.
+// 	void updateCategoryIdsToNull(List<Long> categoryIds){
+// 		queryFactory.update(toast)
+// 			.set(toast.category, (Category)null)
+// 			.where(toast.category.categoryId.in(categoryIds))
+// 			.execute();
+// 		// em.flush(); //test 코드에서는 따로 em을 주입하는 중이므로 테스트 후 넣자.
+// 		// em.clear();
+// 	}
+//
+//
+// 	List<Toast> searchToastsByQuery(Long userId, String query){
+// 		return queryFactory.select(toast)
+// 			.from(toast)
+// 			.leftJoin(toast.user, user).fetchJoin()
+// 			.where(eqToastOwner(userId), containToastTitle(query))
+// 			.fetch();
+// 	}
+// 	private BooleanExpression eqToastOwner(Long userId){
+// 		return userId != null?toast.user.userId.eq(userId):null;
+// 	}
+//
+// 	private BooleanExpression containToastTitle(String query){
+// 		if (query == null || query.isEmpty() || query.isBlank()){
+// 			return null;
+// 		}
+// 		return toast.title.containsIgnoreCase(query);
+// 	}
+//
+//
+//
+// 	Long countAllByUser(User user){
+// 		return null;
+// 	}
+//
+//
+// 	Long countALLByUserAndIsReadTrue(User user){
+// 		return null;
+// 	}
+//
+//
+// 	Long countALLByUserAndIsReadFalse(User user){
+// 		return null;
+// 	}
+//
+//
+// 	Long countAllByCategory(Category category){
+// 		return null;
+// 	}
+//
+//
+// 	Long countAllByCategoryAndIsReadTrue(Category category){
+// 		return null;
+// 	}
+//
+//
+// 	Long countAllByCategoryAndIsReadFalse(Category category){
+// 		return null;
+// 	}
+//
+//
+// 	Integer getUnReadToastNumber(Long userId){
+//
+// 		Integer count = queryFactory.select(toast.count().intValue())
+// 			.from(toast)
+// 			.where(eqToastOwner(userId).and(toast.isRead.isFalse()))
+// 			.fetchOne();
+// 		return (count!=null)?count:0;
+// 	}
+//
+//
+// 	@Query("SELECT COUNT(t) FROM Toast t WHERE t.user=:user AND t.createdAt >= :startOfWeek AND t.createdAt <= :endOfWeek")
+// 	Long countAllByCreatedAtThisWeek(@Param("startOfWeek") LocalDateTime startOfWeek,
+// 		@Param("endOfWeek") LocalDateTime endOfWeek, @Param("user") User user){
+// 		return null;
+// 	}
+//
+//
+// 	@Query("SELECT COUNT(t) FROM Toast t WHERE t.user=:user AND t.isRead = true AND t.updateAt >= :startOfWeek AND t.updateAt <= :endOfWeek")
+// 	Long countAllByUpdateAtThisWeek(@Param("startOfWeek") LocalDateTime startOfWeek,
+// 		@Param("endOfWeek") LocalDateTime endOfWeek,
+// 		@Param("user") User user){
+// 		return null;
+// 	}
+//
+//
+// }

--- a/linkmind/src/main/java/com/app/toaster/popup/controller/PopupController.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/controller/PopupController.java
@@ -1,5 +1,6 @@
 package com.app.toaster.popup.controller;
 
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -16,17 +17,19 @@ import com.app.toaster.common.dto.ApiResponse;
 import com.app.toaster.config.UserId;
 import com.app.toaster.exception.Success;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/popup")
+@Validated
 public class PopupController {
 	private final PopupService popupService;
 
 
 	@PatchMapping
-	public ApiResponse<InvisibleResponseDto> updateInvisible(@UserId Long userId, @RequestBody PopUpRequestDto popUpRequestDto){
+	public ApiResponse<InvisibleResponseDto> updateInvisible(@UserId Long userId, @RequestBody @Valid PopUpRequestDto popUpRequestDto){
 		return ApiResponse.success(Success.UPDATE_POPUP_SUCCESS, popupService.updatePopupInvisible(userId,popUpRequestDto));
 	}
 

--- a/linkmind/src/main/java/com/app/toaster/popup/controller/PopupController.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/controller/PopupController.java
@@ -25,13 +25,13 @@ public class PopupController {
 	private final PopupService popupService;
 
 
-	@PatchMapping("/{userId}")
-	public ApiResponse<InvisibleResponseDto> updateInvisible(@PathVariable Long userId, @RequestBody PopUpRequestDto popUpRequestDto){
+	@PatchMapping
+	public ApiResponse<InvisibleResponseDto> updateInvisible(@UserId Long userId, @RequestBody PopUpRequestDto popUpRequestDto){
 		return ApiResponse.success(Success.UPDATE_POPUP_SUCCESS, popupService.updatePopupInvisible(userId,popUpRequestDto));
 	}
 
-	@GetMapping("/{userId}")
-	public ApiResponse<PopupResponseDto> getPopUpInformation(@PathVariable(name = "userId") Long userId){
+	@GetMapping
+	public ApiResponse<PopupResponseDto> getPopUpInformation(@UserId Long userId){
 		return ApiResponse.success(Success.GET_POPUP_SUCCESS, popupService.findPopupInformation(userId));
 	}
 

--- a/linkmind/src/main/java/com/app/toaster/popup/controller/PopupController.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/controller/PopupController.java
@@ -1,0 +1,38 @@
+package com.app.toaster.popup.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.app.toaster.popup.controller.request.PopUpRequestDto;
+import com.app.toaster.popup.controller.response.InvisibleResponseDto;
+import com.app.toaster.popup.controller.response.PopupResponseDto;
+import com.app.toaster.popup.service.PopupService;
+import com.app.toaster.common.dto.ApiResponse;
+import com.app.toaster.config.UserId;
+import com.app.toaster.exception.Success;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/popup")
+public class PopupController {
+	private final PopupService popupService;
+
+
+	@PatchMapping("/{userId}")
+	public ApiResponse<InvisibleResponseDto> updateInvisible(@PathVariable Long userId, @RequestBody PopUpRequestDto popUpRequestDto){
+		return ApiResponse.success(Success.UPDATE_POPUP_SUCCESS, popupService.updatePopupInvisible(userId,popUpRequestDto));
+	}
+
+	@GetMapping("/{userId}")
+	public ApiResponse<PopupResponseDto> getPopUpInformation(@PathVariable(name = "userId") Long userId){
+		return ApiResponse.success(Success.GET_POPUP_SUCCESS, popupService.findPopupInformation(userId));
+	}
+
+}

--- a/linkmind/src/main/java/com/app/toaster/popup/controller/request/PopUpRequestDto.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/controller/request/PopUpRequestDto.java
@@ -1,0 +1,11 @@
+package com.app.toaster.popup.controller.request;
+
+import jakarta.validation.Valid;
+
+public record PopUpRequestDto(
+	@Valid
+	Long popupId,
+	@Valid
+	boolean invisible
+) {
+}

--- a/linkmind/src/main/java/com/app/toaster/popup/controller/request/PopUpRequestDto.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/controller/request/PopUpRequestDto.java
@@ -1,11 +1,10 @@
 package com.app.toaster.popup.controller.request;
 
-import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 public record PopUpRequestDto(
-	@Valid
 	Long popupId,
-	@Valid
-	boolean invisible
+	@NotNull
+	Long hideDate
 ) {
 }

--- a/linkmind/src/main/java/com/app/toaster/popup/controller/response/InvisibleResponseDto.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/controller/response/InvisibleResponseDto.java
@@ -1,7 +1,12 @@
 package com.app.toaster.popup.controller.response;
 
-public record InvisibleResponseDto(Long popupId, boolean invisible) {
-	public static InvisibleResponseDto of(Long popupId, boolean invisible){
-		return new InvisibleResponseDto(popupId, invisible);
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+public record InvisibleResponseDto(Long popupId, String hideUntil) {
+	public static InvisibleResponseDto of(Long popupId, LocalDate hideUntil){
+		return new InvisibleResponseDto(popupId, hideUntil.format(DateTimeFormatter.ofPattern("YYYY-MM-dd")));
 	}
 }

--- a/linkmind/src/main/java/com/app/toaster/popup/controller/response/InvisibleResponseDto.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/controller/response/InvisibleResponseDto.java
@@ -1,0 +1,7 @@
+package com.app.toaster.popup.controller.response;
+
+public record InvisibleResponseDto(Long popupId, boolean invisible) {
+	public static InvisibleResponseDto of(Long popupId, boolean invisible){
+		return new InvisibleResponseDto(popupId, invisible);
+	}
+}

--- a/linkmind/src/main/java/com/app/toaster/popup/controller/response/PopupResponseDto.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/controller/response/PopupResponseDto.java
@@ -1,0 +1,12 @@
+package com.app.toaster.popup.controller.response;
+
+import java.util.List;
+
+import com.app.toaster.popup.entity.Popup;
+
+public record PopupResponseDto(List<Popup> popupList) {
+
+	public static PopupResponseDto from(List<Popup> popupList){
+		return new PopupResponseDto(popupList);
+	}
+}

--- a/linkmind/src/main/java/com/app/toaster/popup/entity/Popup.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/entity/Popup.java
@@ -1,5 +1,6 @@
 package com.app.toaster.popup.entity;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,20 +29,22 @@ public class Popup {
 	@Column(columnDefinition = "TEXT", name = "image")
 	private String image;
 
-	@Column(name = "active")
-	private boolean active;
+	private LocalDate activeStartDate;
+
+	private LocalDate activeEndDate;
 
 	@Column(name = "link_url")
 	private String linkUrl;
 
 	@Builder
-	private Popup(String image, boolean active, String linkUrl) {
+	private Popup(String image, LocalDate activeStartDate, LocalDate activeEndDate, String linkUrl) {
 		this.image = image;
-		this.active = active;
+		this.activeStartDate = activeStartDate;
+		this.activeEndDate = activeEndDate;
 		this.linkUrl = linkUrl;
 	}
 
-	public void updateIsActive(boolean isActive){
-		this.active = active;
+	public boolean isActivePopup(LocalDate today){
+		return !today.isBefore(activeStartDate)&&!today.isAfter(activeEndDate);
 	}
 }

--- a/linkmind/src/main/java/com/app/toaster/popup/entity/Popup.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/entity/Popup.java
@@ -1,0 +1,47 @@
+package com.app.toaster.popup.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Popup {
+
+	@Id
+	@Column(name = "popup_id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(columnDefinition = "TEXT", name = "image")
+	private String image;
+
+	@Column(name = "active")
+	private boolean active;
+
+	@Column(name = "link_url")
+	private String linkUrl;
+
+	@Builder
+	private Popup(String image, boolean active, String linkUrl) {
+		this.image = image;
+		this.active = active;
+		this.linkUrl = linkUrl;
+	}
+
+	public void updateIsActive(boolean isActive){
+		this.active = active;
+	}
+}

--- a/linkmind/src/main/java/com/app/toaster/popup/entity/PopupInvisibleManager.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/entity/PopupInvisibleManager.java
@@ -1,5 +1,8 @@
 package com.app.toaster.popup.entity;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
@@ -18,6 +21,7 @@ import lombok.NoArgsConstructor;
 /**
  * 유저를 엮을것인가? 그러기에는 userId만 필요함.
  * popup을 엮을 것인가? -> popup이 없어지면 popupmanager도 삭제.
+ * 요구사항 추가: 1일 안보기 + 7일 안보기
  */
 @Entity
 @Getter
@@ -36,16 +40,15 @@ public class PopupInvisibleManager {
 	@JoinColumn(name = "popup_id")
 	private Popup popup;
 
-	private boolean wantToInvisible;
+	private LocalDate hideDateUntil;
 
 	@Builder
 	private PopupInvisibleManager(Long userId, Popup popup, boolean wantToInvisible) {
 		this.userId = userId;
 		this.popup = popup;
-		this.wantToInvisible = wantToInvisible;
 	}
 
-	public void updateInvisible(boolean wantToInvisible){
-		this.wantToInvisible = wantToInvisible;
+	public void updateInvisible(LocalDate untilDate){
+		this.hideDateUntil = untilDate; // 계산해서 넘겨준 untilDate로 바꿈.
 	}
 }

--- a/linkmind/src/main/java/com/app/toaster/popup/entity/PopupInvisibleManager.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/entity/PopupInvisibleManager.java
@@ -1,0 +1,51 @@
+package com.app.toaster.popup.entity;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 유저를 엮을것인가? 그러기에는 userId만 필요함.
+ * popup을 엮을 것인가? -> popup이 없어지면 popupmanager도 삭제.
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PopupInvisibleManager {
+
+	@Id
+	@Column(name = "popup_manager_id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private Long userId;
+
+	@ManyToOne
+	@OnDelete(action = OnDeleteAction.CASCADE)
+	@JoinColumn(name = "popup_id")
+	private Popup popup;
+
+	private boolean wantToInvisible;
+
+	@Builder
+	private PopupInvisibleManager(Long userId, Popup popup, boolean wantToInvisible) {
+		this.userId = userId;
+		this.popup = popup;
+		this.wantToInvisible = wantToInvisible;
+	}
+
+	public void updateInvisible(boolean wantToInvisible){
+		this.wantToInvisible = wantToInvisible;
+	}
+}

--- a/linkmind/src/main/java/com/app/toaster/popup/infrastructure/PopupManagerRepository.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/infrastructure/PopupManagerRepository.java
@@ -11,4 +11,6 @@ import com.app.toaster.popup.entity.PopupInvisibleManager;
 public interface PopupManagerRepository extends JpaRepository<PopupInvisibleManager, Long> {
 	List<PopupInvisibleManager> findByUserId(Long userId);
 	Optional<PopupInvisibleManager> findByUserIdAndPopup(Long userId, Popup popup);
+
+	void deleteAllByUserId(Long userId);
 }

--- a/linkmind/src/main/java/com/app/toaster/popup/infrastructure/PopupManagerRepository.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/infrastructure/PopupManagerRepository.java
@@ -1,0 +1,14 @@
+package com.app.toaster.popup.infrastructure;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.app.toaster.popup.entity.Popup;
+import com.app.toaster.popup.entity.PopupInvisibleManager;
+
+public interface PopupManagerRepository extends JpaRepository<PopupInvisibleManager, Long> {
+	List<PopupInvisibleManager> findByUserId(Long userId);
+	Optional<PopupInvisibleManager> findByUserIdAndPopup(Long userId, Popup popup);
+}

--- a/linkmind/src/main/java/com/app/toaster/popup/infrastructure/PopupRepository.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/infrastructure/PopupRepository.java
@@ -1,0 +1,11 @@
+package com.app.toaster.popup.infrastructure;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.app.toaster.popup.entity.Popup;
+
+public interface PopupRepository extends JpaRepository<Popup, Long> {
+	Optional<Popup> findByIdAndActive(Long id, boolean active);
+}

--- a/linkmind/src/main/java/com/app/toaster/popup/infrastructure/PopupRepository.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/infrastructure/PopupRepository.java
@@ -1,11 +1,8 @@
 package com.app.toaster.popup.infrastructure;
 
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.app.toaster.popup.entity.Popup;
 
 public interface PopupRepository extends JpaRepository<Popup, Long> {
-	Optional<Popup> findByIdAndActive(Long id, boolean active);
 }

--- a/linkmind/src/main/java/com/app/toaster/popup/service/PopupService.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/service/PopupService.java
@@ -1,11 +1,14 @@
 package com.app.toaster.popup.service;
 
+import java.time.LocalDate;
+import java.time.temporal.TemporalAmount;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.BadRequestException;
 import com.app.toaster.exception.model.NotFoundException;
 import com.app.toaster.popup.controller.request.PopUpRequestDto;
 import com.app.toaster.popup.controller.response.InvisibleResponseDto;
@@ -27,40 +30,47 @@ public class PopupService {
 	public InvisibleResponseDto updatePopupInvisible(Long userId, PopUpRequestDto popUpRequestDto) {
 		Popup popup = findActivePopup(popUpRequestDto.popupId());
 
-		PopupInvisibleManager manager = findManagerWithUserIdAndPopup(userId, popup, popUpRequestDto.invisible());
+		PopupInvisibleManager manager = findManagerWithUserIdAndPopup(userId, popup);
+		LocalDate today = LocalDate.now();
 
-		manager.updateInvisible(popUpRequestDto.invisible());
-		return InvisibleResponseDto.of(popup.getId(), manager.isWantToInvisible());
+		manager.updateInvisible(today.plusDays(popUpRequestDto.hideDate()));
+		return InvisibleResponseDto.of(popup.getId(), manager.getHideDateUntil());
 	}
 
 	@Transactional(readOnly = true)
 	public PopupResponseDto findPopupInformation(Long userId) {
 		List<Long> invisibleManagerList = findInvisiblePopupIdList(userId);
 		return PopupResponseDto.from(popupRepository.findAll().stream()
-			.filter(Popup::isActive)
+			.filter((popup) -> popup.isActivePopup(LocalDate.now()))
 			.filter(popup -> !invisibleManagerList.contains(popup.getId()))
 			.toList());
 	}
 
 	private Popup findActivePopup(Long id) {
-		return popupRepository.findByIdAndActive(id, true).orElseThrow(
-			() -> new NotFoundException(Error.NOT_FOUND_POPUP_EXCEPTION, Error.NOT_FOUND_POPUP_EXCEPTION.getMessage()));
+		LocalDate today = LocalDate.now();
+		Popup popup = popupRepository.findById(id)
+			.orElseThrow(()-> new NotFoundException(Error.NOT_FOUND_POPUP_EXCEPTION, Error.NOT_FOUND_POPUP_EXCEPTION.getMessage()));
+		if (!popup.isActivePopup(today)){
+			throw new BadRequestException(Error.BAD_REQUEST_ID, Error.BAD_REQUEST_ID.getMessage());
+		}
+		return popup;
 	}
 
-	private PopupInvisibleManager findManagerWithUserIdAndPopup(Long userId, Popup popup, boolean invisible) {
+	private PopupInvisibleManager findManagerWithUserIdAndPopup(Long userId, Popup popup) {
 		return popupManagerRepository.findByUserIdAndPopup(userId, popup)
 			.orElseGet(() ->
 				popupManagerRepository.save(PopupInvisibleManager.builder()
 					.userId(userId)
 					.popup(popup)
-					.wantToInvisible(invisible)
 					.build())
 			);
 	}
 
 	private List<Long> findInvisiblePopupIdList(Long userId) {
 		return popupManagerRepository.findByUserId(userId).stream()
-			.filter(PopupInvisibleManager::isWantToInvisible)
+			.filter(
+				(manager) -> manager.getHideDateUntil().isAfter(LocalDate.now()) //오늘 날짜는 보여야지
+			)
 			.map(PopupInvisibleManager::getPopup)
 			.map(Popup::getId)
 			.toList();

--- a/linkmind/src/main/java/com/app/toaster/popup/service/PopupService.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/service/PopupService.java
@@ -1,0 +1,68 @@
+package com.app.toaster.popup.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.NotFoundException;
+import com.app.toaster.popup.controller.request.PopUpRequestDto;
+import com.app.toaster.popup.controller.response.InvisibleResponseDto;
+import com.app.toaster.popup.controller.response.PopupResponseDto;
+import com.app.toaster.popup.entity.Popup;
+import com.app.toaster.popup.entity.PopupInvisibleManager;
+import com.app.toaster.popup.infrastructure.PopupManagerRepository;
+import com.app.toaster.popup.infrastructure.PopupRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PopupService {
+	private final PopupManagerRepository popupManagerRepository;
+	private final PopupRepository popupRepository;
+
+	public InvisibleResponseDto updatePopupInvisible(Long userId, PopUpRequestDto popUpRequestDto) {
+		Popup popup = findActivePopup(popUpRequestDto.popupId());
+
+		PopupInvisibleManager manager = findManagerWithUserIdAndPopup(userId, popup, popUpRequestDto.invisible());
+
+		manager.updateInvisible(popUpRequestDto.invisible()); // 어차피 더티체킹시에 똑같으면 쿼리 안나가겠지?
+		return InvisibleResponseDto.of(popup.getId(), manager.isWantToInvisible());
+	}
+
+	@Transactional(readOnly = true)
+	public PopupResponseDto findPopupInformation(Long userId) {
+		List<Long> invisibleManagerList = findInvisiblePopupIdList(userId);
+		return PopupResponseDto.from(popupRepository.findAll().stream()
+			.filter(Popup::isActive)
+			.filter(popup -> !invisibleManagerList.contains(popup.getId()))
+			.toList());
+	}
+
+	private Popup findActivePopup(Long id) {
+		return popupRepository.findByIdAndActive(id, true).orElseThrow(
+			() -> new NotFoundException(Error.NOT_FOUND_POPUP_EXCEPTION, Error.NOT_FOUND_POPUP_EXCEPTION.getMessage()));
+	}
+
+	private PopupInvisibleManager findManagerWithUserIdAndPopup(Long userId, Popup popup, boolean invisible) {
+		return popupManagerRepository.findByUserIdAndPopup(userId, popup)
+			.orElseGet(() ->
+				popupManagerRepository.save(PopupInvisibleManager.builder()
+					.userId(userId)
+					.popup(popup)
+					.wantToInvisible(invisible)
+					.build())
+			);
+	}
+
+	private List<Long> findInvisiblePopupIdList(Long userId) {
+		return popupManagerRepository.findByUserId(userId).stream()
+			.filter(PopupInvisibleManager::isWantToInvisible)
+			.map(PopupInvisibleManager::getPopup)
+			.map(Popup::getId)
+			.toList();
+	}
+}

--- a/linkmind/src/main/java/com/app/toaster/popup/service/PopupService.java
+++ b/linkmind/src/main/java/com/app/toaster/popup/service/PopupService.java
@@ -29,7 +29,7 @@ public class PopupService {
 
 		PopupInvisibleManager manager = findManagerWithUserIdAndPopup(userId, popup, popUpRequestDto.invisible());
 
-		manager.updateInvisible(popUpRequestDto.invisible()); // 어차피 더티체킹시에 똑같으면 쿼리 안나가겠지?
+		manager.updateInvisible(popUpRequestDto.invisible());
 		return InvisibleResponseDto.of(popup.getId(), manager.isWantToInvisible());
 	}
 

--- a/linkmind/src/main/java/com/app/toaster/service/UserService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/UserService.java
@@ -17,6 +17,8 @@ import com.app.toaster.exception.model.NotFoundException;
 import com.app.toaster.infrastructure.ToastRepository;
 import com.app.toaster.infrastructure.UserRepository;
 
+// import com.app.toaster.infrastructure.querydsl.CustomToastRepository;
+
 import lombok.RequiredArgsConstructor;
 
 import java.time.DayOfWeek;
@@ -31,6 +33,8 @@ public class UserService {
 
 	private final UserRepository userRepository;
 	private final ToastRepository toastRepository;
+
+	// private final CustomToastRepository customToastRepository;
 	private final CategoryRepository categoryRepository;
 
 	@Transactional(readOnly = true)
@@ -87,6 +91,7 @@ public class UserService {
                         .categoryId(category.getCategoryId())
                         .categoryTitle(category.getTitle())
                         .toastNum(toastRepository.getAllByCategory(category).size()).build()
+
                 ).collect(Collectors.toList())).build();
 
         return mainPageResponseDto;

--- a/linkmind/src/main/java/com/app/toaster/service/auth/AuthService.java
+++ b/linkmind/src/main/java/com/app/toaster/service/auth/AuthService.java
@@ -26,6 +26,8 @@ import com.app.toaster.infrastructure.CategoryRepository;
 import com.app.toaster.infrastructure.TimerRepository;
 import com.app.toaster.infrastructure.ToastRepository;
 import com.app.toaster.infrastructure.UserRepository;
+import com.app.toaster.popup.entity.PopupInvisibleManager;
+import com.app.toaster.popup.infrastructure.PopupManagerRepository;
 import com.app.toaster.service.auth.apple.AppleSignInService;
 import com.app.toaster.service.auth.kakao.KakaoSignInService;
 import com.app.toaster.service.auth.kakao.LoginResult;
@@ -43,6 +45,7 @@ public class AuthService {
 
 	private final UserRepository userRepository;
 	private final CategoryRepository categoryRepository;
+	private final PopupManagerRepository popupManagerRepository;
 
 	private final SlackApi slackApi;
 
@@ -149,6 +152,7 @@ public class AuthService {
 		}
 		timerRepository.deleteAllByUser(user);
 		categoryRepository.deleteAllByUser(user);
+		popupManagerRepository.deleteAllByUserId(userId);
 
 		Long res = userRepository.deleteByUserId(userId); //res가 삭제된 컬럼의 개수 즉, 1이 아니면 뭔가 알 수 없는 에러.
 

--- a/linkmind/src/test/java/com/app/toaster/base/BaseRepositoryTest.java
+++ b/linkmind/src/test/java/com/app/toaster/base/BaseRepositoryTest.java
@@ -1,0 +1,15 @@
+package com.app.toaster.base;
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+// import com.app.toaster.config.TestJpaQueryFactoryConfig;
+
+// @Import(TestJpaQueryFactoryConfig.class) -> 쿼리dsl 사용 시 사용할 것.
+@DataJpaTest //@Transactional 어노테이션을 포함하고 있다. 그래서 테스트가 완료되면 자동으로 롤백.
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("local")
+public abstract class BaseRepositoryTest {
+}

--- a/linkmind/src/test/java/com/app/toaster/config/TestJpaQueryFactoryConfig.java
+++ b/linkmind/src/test/java/com/app/toaster/config/TestJpaQueryFactoryConfig.java
@@ -1,0 +1,23 @@
+// package com.app.toaster.config;
+//
+// import org.springframework.boot.test.context.TestConfiguration;
+// import org.springframework.context.annotation.Bean;
+// import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+//
+// import com.querydsl.jpa.impl.JPAQueryFactory;
+//
+// import jakarta.persistence.EntityManager;
+// import jakarta.persistence.PersistenceContext;
+//
+// @EnableJpaAuditing
+// @TestConfiguration
+// public class TestJpaQueryFactoryConfig {
+//
+// 	@PersistenceContext
+// 	private EntityManager entityManager;
+//
+// 	@Bean
+// 	JPAQueryFactory jpaQueryFactory(){
+// 		return new JPAQueryFactory(entityManager);
+// 	}
+// }

--- a/linkmind/src/test/java/com/app/toaster/infrastructure/querydsl/CustomToastRepositoryTest.java
+++ b/linkmind/src/test/java/com/app/toaster/infrastructure/querydsl/CustomToastRepositoryTest.java
@@ -1,0 +1,293 @@
+// package com.app.toaster.infrastructure.querydsl;
+//
+// import static com.app.toaster.domain.QToast.*;
+// import static com.app.toaster.fixture.Fixture.*;
+// import static org.junit.jupiter.api.Assertions.*;
+//
+// import java.util.ArrayList;
+// import java.util.List;
+//
+// import org.assertj.core.api.Assertions;
+// import org.junit.jupiter.api.AfterEach;
+// import org.junit.jupiter.api.BeforeEach;
+// import org.junit.jupiter.api.DisplayName;
+// import org.junit.jupiter.api.Nested;
+// import org.junit.jupiter.api.Test;
+// import org.junit.jupiter.api.extension.ExtendWith;
+// import org.springframework.beans.factory.annotation.Autowired;
+// import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+// import org.springframework.context.annotation.Import;
+// import org.springframework.test.context.junit.jupiter.SpringExtension;
+// import org.springframework.transaction.annotation.Transactional;
+//
+// import com.app.toaster.config.JpaQueryFactoryConfig;
+// import com.app.toaster.domain.Toast;
+// import com.app.toaster.fixture.Fixture;
+// import com.app.toaster.infrastructure.CategoryRepository;
+// import com.app.toaster.infrastructure.ToastRepository;
+// import com.app.toaster.infrastructure.UserRepository;
+// import com.querydsl.core.types.dsl.BooleanExpression;
+// import com.querydsl.jpa.impl.JPAQueryFactory;
+//
+// import jakarta.persistence.EntityManager;
+// import lombok.extern.slf4j.Slf4j;
+//
+// @Slf4j
+// @ExtendWith(SpringExtension.class)
+// @DataJpaTest(showSql = true)
+// @Import(JpaQueryFactoryConfig.class)
+// class CustomToastRepositoryTest {
+//
+// 	CustomToastRepository customToastRepository;
+// 	JPAQueryFactory jpaQueryFactory;
+//
+// 	@Autowired
+// 	ToastRepository toastRepository;
+//
+// 	@Autowired
+// 	UserRepository userRepository;
+//
+// 	@Autowired
+// 	CategoryRepository categoryRepository;
+//
+// 	@Autowired
+// 	EntityManager em;
+//
+// 	@BeforeEach
+// 	void setup() {
+// 		jpaQueryFactory = new JPAQueryFactory(em);
+// 		customToastRepository = new CustomToastRepository(jpaQueryFactory);
+//
+// 		userRepository.save(USER_1);
+// 		categoryRepository.save(CATEGORY_1);
+// 		categoryRepository.save(CATEGORY_2);
+// 		toastRepository.save(TOAST_1);
+// 		toastRepository.save(TOAST_2);
+// 		toastRepository.save(TOAST_3);
+// 	}
+// 	@AfterEach
+// 	void tearDown() {
+// 		// 테스트 후 정리 작업 수행
+// 		em.clear();
+// 		userRepository.deleteAll();
+// 		categoryRepository.deleteAll();
+// 		toastRepository.deleteAll();
+// 	}
+//
+//
+// 	@Nested
+// 	@DisplayName("토스트 jpa repository test")
+// 	class 토스트_JpaRepository_Test {
+//
+// 		@Nested
+// 		@DisplayName("토스트 카테고리 jpa repository test")
+// 		class 토스트_카테고리_jpa_test{
+// 			@Test
+// 			@DisplayName("토스트의 getAllByCategory test")
+// 			void test_ToastJpaRepository_조회() {
+//
+// 				List<Toast> toastList = toastRepository.getAllByCategory(CATEGORY_1);
+//
+//
+// 				Assertions.assertThat(toastList.get(0).getId()).isEqualTo(Fixture.TOAST_1.getId());
+// 				Assertions.assertThat(toastList.get(1).getId()).isEqualTo(Fixture.TOAST_2.getId());
+// 				Assertions.assertThat(toastList.get(2).getId()).isEqualTo(Fixture.TOAST_3.getId());
+// 			}
+// 		}
+// 		@Nested
+// 		@DisplayName("토스트 jpa repository 검색 test")
+// 		class 토스트_JPA_검색_test{
+//
+// 			@Test
+// 			@DisplayName("토스트의 검색 쿼리 문자열이 앞에 있는 경우 test")
+// 			void test_ToastJpaRepository_검색1(){
+// 				List<Toast> toastList = toastRepository.searchToastsByQuery(USER_1.getUserId(),"검색");
+//
+// 				Assertions.assertThat(toastList.get(0).getId()).isEqualTo(Fixture.TOAST_1.getId());
+// 				Assertions.assertThat(toastList.get(1).getId()).isEqualTo(Fixture.TOAST_2.getId());
+// 				Assertions.assertThat(toastList.get(2).getId()).isEqualTo(Fixture.TOAST_3.getId());
+// 			}
+//
+// 			@Test
+// 			@DisplayName("토스트의 검색 쿼리 문자열이 뒤에 있는 경우 test")
+// 			void test_ToastJpaRepository_검색2(){
+// 				List<Toast> toastList = toastRepository.searchToastsByQuery(USER_1.getUserId(),"되나");
+//
+// 				Assertions.assertThat(toastList.get(0).getId()).isEqualTo(TOAST_1.getId());
+// 				Assertions.assertThat(toastList.get(1).getId()).isEqualTo(TOAST_3.getId());
+// 				// Assertions.assertThat(toastList.get(2).getId()).isEqualTo(Fixture.TOAST_3.getId());
+// 			}
+//
+// 		}
+//
+// 		@DisplayName("토스트 수정 관련 jpa test")
+// 		@Nested
+// 		class 토스트_JPA_수정_TEST{
+// 			@Test
+// 			@DisplayName("토스트 수정 쿼리 jpa test")
+// 			@Transactional
+// 			void updateCategoryIdsToNull(){
+// 				//given
+// 				List<Long> categoryIds = new ArrayList<>();
+// 				categoryIds.add(CATEGORY_1.getCategoryId());
+// 				categoryIds.add(CATEGORY_2.getCategoryId());
+//
+// 				//when
+// 				toastRepository.updateCategoryIdsToNull(categoryIds);
+//
+// 				//then
+// 				Assertions.assertThat(TOAST_1.getCategory() == null);
+// 				Assertions.assertThat(TOAST_2.getCategory() == null);
+// 				Assertions.assertThat(TOAST_3.getCategory() == null);
+// 				Assertions.assertThat(TOAST_3_CATEGORY_2.getCategory() == null);
+// 			}
+// 		}
+// 	}
+// 	@Nested
+// 	@DisplayName("토스트 querydsl test")
+// 	class 토스트_QueryDSL_Test{
+// 		@Nested
+// 		@DisplayName("토스트 QueryDSL category test")
+// 		class 토스트_QueryDSL_Category_Test {
+//
+// 			@Test
+// 			@DisplayName("토스트의 queryDSL getAllByCategory test")
+// 			void ToastQueryRepository_getAllByCategory_테스트() {
+//
+// 				List<Toast> toasts = customToastRepository.getAllByCategory(CATEGORY_1);
+//
+// 				Assertions.assertThat(toasts.get(0).getId()).isEqualTo(Fixture.TOAST_1.getId());
+// 				Assertions.assertThat(toasts.get(1).getId()).isEqualTo(Fixture.TOAST_2.getId());
+// 				Assertions.assertThat(toasts.get(2).getId()).isEqualTo(Fixture.TOAST_3.getId());
+// 			}
+//
+// 			@Test
+// 			@DisplayName("categoryid 결과를 찾지 못했을 때 test")
+// 			void ToastQueryRepository_Category_id_2_테스트() {
+//
+// 				List<Toast> toasts = jpaQueryFactory.selectFrom(toast)
+// 					.where(eqCategoryId(CATEGORY_2.getCategoryId()))
+// 					.fetch();
+// 				assertNotNull(toasts, "조회 데이터가 없습니다.");
+// 				// Assertions.assertThat(toasts.get(0).getId()).isEqualTo(Fixture.TOAST_2.getId());
+// 				// Assertions.assertThat(toasts.get(0).getId()).isEqualTo(Fixture.TOAST_3.getId());
+// 			}
+//
+// 		}
+//
+// 		@Nested
+// 		@DisplayName("토스트 QueryDSL search test")
+// 		class 토스트_QueryDSL_검색쿼리_test{
+// 			@Test
+// 			@DisplayName("토스트의 queryDSL 문자열이 앞에 있을 때 쿼리 검색 test")
+// 			@Transactional(readOnly = true)
+// 			void ToastQueryRepository_searchToastsByQuery_테스트() {
+//
+// 				List<Toast> toasts = customToastRepository.searchToastsByQuery(USER_1.getUserId(), "검색");
+//
+// 				Assertions.assertThat(toasts.get(0).getId()).isEqualTo(Fixture.TOAST_1.getId());
+// 				Assertions.assertThat(toasts.get(1).getId()).isEqualTo(Fixture.TOAST_2.getId());
+// 				Assertions.assertThat(toasts.get(2).getId()).isEqualTo(Fixture.TOAST_3.getId());
+// 			}
+//
+// 			@Test
+// 			@DisplayName("토스트의 queryDSL 문자열이 뒤에 있을 때 쿼리 검색 test")
+// 			@Transactional(readOnly = true)
+// 			void ToastQueryRepository_searchToastsByQuery_테스트2() {
+//
+// 				List<Toast> toasts = customToastRepository.searchToastsByQuery(USER_1.getUserId(), "되나");
+//
+// 				Assertions.assertThat(toasts.get(0).getId()).isEqualTo(Fixture.TOAST_1.getId());
+// 				Assertions.assertThat(toasts.get(1).getId()).isEqualTo(Fixture.TOAST_3.getId());
+// 				// Assertions.assertThat(toasts.get(2).getId()).isEqualTo(Fixture.TOAST_3.getId());
+// 			}
+//
+// 			@Test
+// 			@DisplayName("검색 쿼리가 비어있을 때")
+// 			@Transactional(readOnly = true)
+// 			void ToastQueryRepository_searchToastsByQuery_테스트3() {
+//
+// 				List<Toast> toasts = customToastRepository.searchToastsByQuery(USER_1.getUserId(), "");
+//
+// 				Assertions.assertThat(toasts.get(0).getId()).isEqualTo(Fixture.TOAST_1.getId());
+// 				Assertions.assertThat(toasts.get(1).getId()).isEqualTo(Fixture.TOAST_2.getId());
+// 				Assertions.assertThat(toasts.get(2).getId()).isEqualTo(Fixture.TOAST_3.getId());
+// 			}
+// 		}
+// 		//적용하더라도 프로덕션 코드의 em부분 em.flush, em.clear체크.
+//
+// 		@Nested
+// 		@DisplayName("토스트 수정 관련 querydsl test")
+// 		class 토스트_QueryDSL_수정_TEST{
+// 			@Test
+// 			@DisplayName("토스트 수정 쿼리 querydsl test")
+// 			@Transactional
+// 			void updateCategoryIdsToNull(){
+// 				//given
+// 				List<Long> categoryIds = new ArrayList<>();
+// 				categoryIds.add(CATEGORY_1.getCategoryId());
+// 				categoryIds.add(CATEGORY_2.getCategoryId());
+//
+// 				//when
+// 				customToastRepository.updateCategoryIdsToNull(categoryIds);
+// 				//
+// 				em.flush();
+// 				em.clear();
+//
+// 				//then
+// 				Assertions.assertThat(TOAST_1.getCategory() == null);
+// 				Assertions.assertThat(TOAST_2.getCategory() == null);
+// 				Assertions.assertThat(TOAST_3.getCategory() == null);
+// 				Assertions.assertThat(TOAST_3_CATEGORY_2.getCategory() == null);
+// 			}
+// 		}
+//
+// 		@Nested
+// 		@DisplayName("토스트 QueryDSL 안읽은 토스트 개수 세기 test")
+// 		class 토스트_QueryDSL_안읽은_토스트_개수_세기_test{
+//
+// 			@Test
+// 			@DisplayName("안읽은 토스트 개수 세기 쿼리 querydsl test")
+// 			void countUnReadToast(){
+// 				//given
+// 				TOAST_1.updateIsRead(false);
+// 				TOAST_2.updateIsRead(false);
+// 				em.flush();
+//
+// 				//when
+// 				Integer res = customToastRepository.getUnReadToastNumber(USER_1.getUserId());
+// 				//
+// 				//em.clear();
+//
+// 				//then
+// 				Assertions.assertThat(res == 2);
+// 			}
+//
+// 			@Test
+// 			@DisplayName("안 읽은 토스트 개수가 없는 경우. querydsl test")
+// 			void countUnReadToastAtNotFoundCase(){
+// 				//given
+// 				TOAST_1.updateIsRead(true);
+// 				TOAST_2.updateIsRead(true);
+// 				TOAST_3.updateIsRead(true);
+// 				em.flush();
+//
+// 				//when
+// 				Integer res = customToastRepository.getUnReadToastNumber(USER_1.getUserId());
+// 				//
+// 				//em.clear();
+//
+// 				//then
+// 				Assertions.assertThat(res == 0);
+// 			}
+//
+// 		}
+// 	}
+//
+//
+//
+// 	private BooleanExpression eqCategoryId(Long id){
+// 		return id!=null?toast.category.categoryId.eq(id):null;
+// 	}
+//
+// }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #240 
- close #239 

## 📋 구현 기능 명세
- [x]  queryDSL 테스트 결과 별 차이 없어서 production 문제 안생기게 주석처리
- [x]  팝업 안보이기 기능
- [x]  팝업 정보 보이기 기능
- [x]   테스트
- [x] 최종 추가 커밋

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
엔티티 관련해서 현재 user - popupInvisibleManager-popup와 같이 중간테이블 관계로 되어있습니다. 
popupManager에서 userId외에 유저 정보를 하나도 가지고 있을 필요가 없어보여서 userid는 엔티티로 안엮은 다음에 
user삭제 로직에 → popupmanagerrepository.deleteByUserId() 한줄 추가할 생각입니당. -> 코드 상 고칠 거 없으면 추가 커밋으로 올리겠습니다.

popup과 popupmanager는 생명주기를 cascade설정을 통해 삭제되게 구현해봤고, 양방향 연관관계까지는 필요없어서 `on_delete` 옵션으로 처리했습니다.

📌 삭제 쿼리로 popup 제거시 manager 같이 삭제 확인함.

현재 컨트롤러부는 테스트를 위해 pathVariable로 해놨고, 추가 커밋에서 한꺼번에 엑세스토큰을 받아 userId를 반환하는식으로 수정하겠습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지
저희가 패키지 구조를 원래 한번에 몰아넣는 식으로 구성했었는데, 이번 팝업과 같이 도메인 별로 분리해보는 것이 어떨까싶어서 팝업부분을 다음과 같은 예시로 해봤습니다..! 오히려 파일을 찾기 어렵다 판단되면 추가 커밋에서 구조 원래대로 옮겨서 푸시하겠습니다!

- 개발하면서 어떤 점이 궁금했는지
예외 상황이 없을까요? 일단 관리자 페이지를 나중에 만든다는 가정하에 서버단에서 생성, 삭제 api도 추가로 구현해놓는게 좋을지?

## 📸 결과물 스크린샷
```json 
{
    "code": 200,
    "message": "팝업 정보 조회 성공",
    "data": {
        "popupList": [
            {
                "id": 1,
                "image": "ddd",
                "active": true,
                "linkUrl": "dfsadf"
            },
            {
                "id": 2,
                "image": "dddd",
                "active": true,
                "linkUrl": "dfsadf"
            }
        ]
    }
}

```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/api/v2/popup
