### PR TITLE
[#245] refactor: 토스트 제목 수정 validation 수정 및 그룹설정

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/controller/valid/TitleValid.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/valid/TitleValid.java
@@ -17,5 +17,5 @@ public @interface TitleValid {
 	String message() default "Invalid title";
 	Class<?>[] groups() default {};
 	Class<? extends Payload>[] payload() default {};
-	String pattern() default "[가-힣|a-z|A-Z|0-9|]";
+	String pattern() default "^[\\S][가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9\\s]{0,20}$";
 }

--- a/linkmind/src/main/java/com/app/toaster/controller/valid/TitleValidator.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/valid/TitleValidator.java
@@ -1,18 +1,17 @@
 package com.app.toaster.controller.valid;
 
-
-import com.app.toaster.exception.Error;
-import com.app.toaster.exception.model.CustomException;
-
+import com.app.toaster.controller.valid.marker.ToastValidationGroup;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
 public class TitleValidator implements ConstraintValidator<TitleValid, String> {
 
-	public String pattern;
+	private String pattern;
+	private Class<?>[] groups;
 	@Override
 	public void initialize(TitleValid constraintAnnotation) {
 		this.pattern = constraintAnnotation.pattern();
+		this.groups = constraintAnnotation.groups();
 	}
 
 	@Override
@@ -39,18 +38,27 @@ public class TitleValidator implements ConstraintValidator<TitleValid, String> {
 			return false;
 		}
 
-		if(title.length()>15){
+		if(!isGroupActive(ToastValidationGroup.class) && title.length()>15){ //토스트쪽이 아니면 검증을 합니다.
 			context.buildConstraintViolationWithTemplate("이름은 최대 15자까지 입력 가능해요")
 					.addConstraintViolation();
 			return false;
 		}
 
-		if(!title.matches("^[\\S][가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9\\s]{0,20}$")){
+		if(!title.matches(pattern)){
 			context.buildConstraintViolationWithTemplate("특수 문자로는 검색할 수 없어요.")
 				.addConstraintViolation();
 			return false;
 		}
 
 		return true;
+	}
+
+	private boolean isGroupActive(Class<?> targetGroup) {
+		for (Class<?> group : groups) {
+			if (group.equals(targetGroup)) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/linkmind/src/main/java/com/app/toaster/controller/valid/marker/ToastValidationGroup.java
+++ b/linkmind/src/main/java/com/app/toaster/controller/valid/marker/ToastValidationGroup.java
@@ -1,0 +1,4 @@
+package com.app.toaster.controller.valid.marker;
+
+public interface ToastValidationGroup {
+}

--- a/linkmind/src/main/java/com/app/toaster/toast/controller/request/UpdateToastDto.java
+++ b/linkmind/src/main/java/com/app/toaster/toast/controller/request/UpdateToastDto.java
@@ -3,9 +3,10 @@ package com.app.toaster.toast.controller.request;
 import com.app.toaster.controller.valid.Severity;
 import com.app.toaster.controller.valid.TitleValid;
 
+import com.app.toaster.controller.valid.marker.ToastValidationGroup;
 import jakarta.validation.constraints.NotNull;
 
-public record UpdateToastDto(Long toastId, @TitleValid(payload = Severity.Error.class) @NotNull String title) {
+public record UpdateToastDto(Long toastId, @TitleValid(payload = Severity.Error.class, groups = {ToastValidationGroup.class}) @NotNull String title) {
 	public static UpdateToastDto of(Long toastId, String title){
 		return new UpdateToastDto(toastId,title);
 	}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #245 

## 📋 구현 기능 명세
- [x] 토스트 제목 수정 validation 수정
- [x] 토스트 마크 그룹 인터페이스 생성

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
먼저, 전에 있었던 패턴 코드에서 사용하지 않는 정규식 패턴을 default값으로 가지고 있었어서 수정했습니다.
그리고 나머지 제목 검증로직은 카테고리에서든, 검색에서든 거의 비슷하게 동작해야하는데 따로 어노테이션을 만드는 것보다는
마크할 그룹 인터페이스를 하나 만들어서 해당 이름을 어노테이션을 통해 검증해서 ToastValidationGroup.class를 가지고 있으면 해당 검증은 피하는식으로
변경했습니다.

- 개발하면서 어떤 점이 궁금했는지
다른 의견이 있을지..!

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- baseurl/toast/title
