### PR TITLE
fix: 빈 url 줄 때 대응 추가

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/exception/Error.java
+++ b/linkmind/src/main/java/com/app/toaster/exception/Error.java
@@ -28,7 +28,7 @@ public enum Error {
 	 */
 	BAD_REQUEST_ISREAD(HttpStatus.BAD_REQUEST, "isRead 값이 잘못요청 되었습니다."),
 	BAD_REQUEST_ID(HttpStatus.BAD_REQUEST, "잘못된 id값입니다."),
-	EMPTY_URL(HttpStatus.BAD_REQUEST, "빈 url로는 저장할 수 없습니다."),
+	BAD_REQUEST_EMPTY_URL(HttpStatus.BAD_REQUEST, "빈 url로는 저장할 수 없습니다."),
 
 	BAD_REQUEST_VALIDATION(HttpStatus.BAD_REQUEST, "유효한 값으로 요청을 다시 보내주세요."),
 	BAD_REQUEST_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "파일형식이 잘못된 것 같습니다."),

--- a/linkmind/src/main/java/com/app/toaster/exception/Error.java
+++ b/linkmind/src/main/java/com/app/toaster/exception/Error.java
@@ -22,11 +22,14 @@ public enum Error {
 	NOT_FOUND_TIMER(HttpStatus.NOT_FOUND, "찾을 수 없는 타이머입니다."),
 	NOT_FOUND_POPUP_EXCEPTION(HttpStatus.NOT_FOUND, "유효하지 않은 팝업입니다."),
 
+
 	/**
 	 * 400 BAD REQUEST EXCEPTION
 	 */
 	BAD_REQUEST_ISREAD(HttpStatus.BAD_REQUEST, "isRead 값이 잘못요청 되었습니다."),
 	BAD_REQUEST_ID(HttpStatus.BAD_REQUEST, "잘못된 id값입니다."),
+	EMPTY_URL(HttpStatus.BAD_REQUEST, "빈 url로는 저장할 수 없습니다."),
+
 	BAD_REQUEST_VALIDATION(HttpStatus.BAD_REQUEST, "유효한 값으로 요청을 다시 보내주세요."),
 	BAD_REQUEST_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "파일형식이 잘못된 것 같습니다."),
 	BAD_REQUEST_FILE_SIZE(HttpStatus.BAD_REQUEST, "파일크기가 잘못된 것 같습니다. 최대 5MB"),

--- a/linkmind/src/main/java/com/app/toaster/toast/service/ToastService.java
+++ b/linkmind/src/main/java/com/app/toaster/toast/service/ToastService.java
@@ -51,9 +51,11 @@ public class ToastService {
 	public void createToast(Long userId, SaveToastDto saveToastDto){
 		//해당 유저 탐색
 		User presentUser = findUser(userId);
+		if (saveToastDto.linkUrl() ==null || saveToastDto.linkUrl().isBlank()){
+			throw new CustomException(Error.EMPTY_URL, Error.EMPTY_URL.getMessage());
+		}
 		//토스트 생성
 		try {
-			System.out.println(saveToastDto.linkUrl());
 			OgResponse res = parsingService.getOg(saveToastDto.linkUrl());
 			//byte 배열로 읽어들임.
 			log.info(res.titleAdvanced());
@@ -62,6 +64,7 @@ public class ToastService {
 			// // ImagePresignedUrlResponse realRes = getUploadPreSignedUrl(res.imageAdvanced());
 			// log.info(realRes.fileName());
 			// log.info(realRes.preSignedUrl());
+
 
 			//presigned url
 			Toast toast = Toast.builder()

--- a/linkmind/src/main/java/com/app/toaster/toast/service/ToastService.java
+++ b/linkmind/src/main/java/com/app/toaster/toast/service/ToastService.java
@@ -52,7 +52,7 @@ public class ToastService {
 		//해당 유저 탐색
 		User presentUser = findUser(userId);
 		if (saveToastDto.linkUrl() ==null || saveToastDto.linkUrl().isBlank()){
-			throw new CustomException(Error.EMPTY_URL, Error.EMPTY_URL.getMessage());
+			throw new CustomException(Error.BAD_REQUEST_EMPTY_URL, Error.BAD_REQUEST_EMPTY_URL.getMessage());
 		}
 		//토스트 생성
 		try {

--- a/linkmind/src/test/java/com/app/toaster/toast/service/ToastServiceTest.java
+++ b/linkmind/src/test/java/com/app/toaster/toast/service/ToastServiceTest.java
@@ -1,0 +1,143 @@
+package com.app.toaster.toast.service;
+
+import com.app.toaster.category.domain.Category;
+import com.app.toaster.category.infrastructure.CategoryRepository;
+import com.app.toaster.category.service.CategoryService;
+import com.app.toaster.exception.Error;
+import com.app.toaster.exception.model.CustomException;
+import com.app.toaster.parse.controller.response.OgResponse;
+import com.app.toaster.parse.service.ParsingService;
+import com.app.toaster.toast.controller.request.SaveToastDto;
+import com.app.toaster.toast.domain.Toast;
+import com.app.toaster.toast.infrastructure.ToastRepository;
+import com.app.toaster.user.domain.User;
+import com.app.toaster.user.infrastructure.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ToastServiceTest {
+
+    @Mock
+    private ToastRepository toastRepository;
+
+    @Mock
+    private ParsingService parsingService;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private UserRepository userRepository; // findUser 메소드를 위해 필요할 수 있음
+
+    @InjectMocks
+    private ToastService toastService;
+
+    private User testUser;
+
+    private Category testCategory;
+    private SaveToastDto validSaveToastDto;
+    private OgResponse mockOgResponse;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .socialId("testUser")
+                .nickname("test")
+                .build();
+
+        validSaveToastDto = new SaveToastDto("https://example.com", 1L);
+
+        mockOgResponse = OgResponse.of("Test Title", "https://example.com/image.jpg");
+
+        testCategory = Category.builder()
+                .priority(0)
+                .title("hi")
+                .user(testUser)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Toast 생성 성공 테스트")
+    void createToast_Success() throws IOException {
+        // given
+        Long userId = 1L;
+
+
+        when(userRepository.findByUserId(userId)).thenReturn(Optional.of(testUser));
+        when(parsingService.getOg(validSaveToastDto.linkUrl())).thenReturn(mockOgResponse);
+        when(categoryRepository.findById(userId)).thenReturn(Optional.of(testCategory));
+
+        // when
+        toastService.createToast(userId, validSaveToastDto);
+
+        // then
+        verify(parsingService, times(1)).getOg(validSaveToastDto.linkUrl());
+        verify(toastRepository, times(1)).save(any(Toast.class));
+
+        // Toast 객체가 올바르게 생성되는지 확인
+        ArgumentCaptor<Toast> toastCaptor = ArgumentCaptor.forClass(Toast.class);
+        verify(toastRepository).save(toastCaptor.capture());
+
+        Toast savedToast = toastCaptor.getValue();
+        assertThat(savedToast.getUser()).isEqualTo(testUser);
+        assertThat(savedToast.getLinkUrl()).isEqualTo(validSaveToastDto.linkUrl());
+        assertThat(savedToast.getTitle()).isEqualTo(mockOgResponse.titleAdvanced());
+    }
+
+    @Test
+    @DisplayName("URL이 null인 경우 EMPTY_URL 에러를 반환한다.")
+    void createToast_Fail_NullUrl() {
+        // given
+        Long userId = 1L;
+
+        SaveToastDto invalidDto = new SaveToastDto(null, 1L);
+
+        when(userRepository.findByUserId(userId)).thenReturn(Optional.of(testUser));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> toastService.createToast(userId, invalidDto));
+
+        assertThat(exception.getError()).isEqualTo(Error.EMPTY_URL);
+    }
+
+    @Test
+    @DisplayName("URL이 빈 문자열인 경우 EMPTY_URL에러를 반환한다.")
+    void createToast_Fail_EmptyUrl() {
+        // given
+        Long userId = 1L;
+
+        SaveToastDto invalidDto = new SaveToastDto("", 1L);
+        SaveToastDto invalidDto2 = new SaveToastDto(" ", 1L);
+
+
+        when(userRepository.findByUserId(userId)).thenReturn(Optional.of(testUser));
+
+        // when & then
+        CustomException exception1 = assertThrows(CustomException.class,
+                () -> toastService.createToast(userId, invalidDto));
+        CustomException exception2 = assertThrows(CustomException.class,
+                () -> toastService.createToast(userId, invalidDto2));
+
+        assertThat(exception1.getError()).isEqualTo(Error.EMPTY_URL);
+        assertThat(exception2.getError()).isEqualTo(Error.EMPTY_URL);
+
+    }
+
+
+
+}

--- a/linkmind/src/test/java/com/app/toaster/toast/service/ToastServiceTest.java
+++ b/linkmind/src/test/java/com/app/toaster/toast/service/ToastServiceTest.java
@@ -2,7 +2,6 @@ package com.app.toaster.toast.service;
 
 import com.app.toaster.category.domain.Category;
 import com.app.toaster.category.infrastructure.CategoryRepository;
-import com.app.toaster.category.service.CategoryService;
 import com.app.toaster.exception.Error;
 import com.app.toaster.exception.model.CustomException;
 import com.app.toaster.parse.controller.response.OgResponse;
@@ -112,7 +111,7 @@ class ToastServiceTest {
         CustomException exception = assertThrows(CustomException.class,
                 () -> toastService.createToast(userId, invalidDto));
 
-        assertThat(exception.getError()).isEqualTo(Error.EMPTY_URL);
+        assertThat(exception.getError()).isEqualTo(Error.BAD_REQUEST_EMPTY_URL);
     }
 
     @Test
@@ -133,8 +132,8 @@ class ToastServiceTest {
         CustomException exception2 = assertThrows(CustomException.class,
                 () -> toastService.createToast(userId, invalidDto2));
 
-        assertThat(exception1.getError()).isEqualTo(Error.EMPTY_URL);
-        assertThat(exception2.getError()).isEqualTo(Error.EMPTY_URL);
+        assertThat(exception1.getError()).isEqualTo(Error.BAD_REQUEST_EMPTY_URL);
+        assertThat(exception2.getError()).isEqualTo(Error.BAD_REQUEST_EMPTY_URL);
 
     }
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #267

## 📋 구현 기능 명세
- [x] 빈 url일 때 400 던져주기

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
네트워크 지연등으로 응답이 바로 안올때 url 빈 상태로 넘어가는 듯하여 대응추가

- 어떤 부분에 리뷰어가 집중해야 하는지
저희 유저 갑자기 늘어나는데.. 올만에 코드 좀 볼까요.. ㅋㅌ ㅜㅜ

- 개발하면서 어떤 점이 궁금했는지
저 요즘 헥사고날 공부하고잇는데 수습 끝나면 한번 연습할겸 적용해도될까용?


## 📸 결과물 스크린샷
```java
결과 예시 사진 첨부
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- 
