### PR TITLE
[#271] fix: title column 타입 text로 변경

### DIFF
--- a/linkmind/src/main/java/com/app/toaster/toast/domain/Toast.java
+++ b/linkmind/src/main/java/com/app/toaster/toast/domain/Toast.java
@@ -27,6 +27,7 @@ public class Toast {
 	@JoinColumn(name = "category_id")
 	private Category category;
 
+	@Column(columnDefinition = "TEXT")
 	private String title;
 
 	@Column(columnDefinition = "TEXT")


### PR DESCRIPTION
## 🚩 관련 이슈
- close #271 

## 📋 구현 기능 명세
- [x] title too long 에러 잡기

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
toast의 title의 길이가 길때 too long 에러 발생 VARCHAR(255)-> text 타입변경

- 어떤 부분에 리뷰어가 집중해야 하는지
현재 title text 타입으로 바꾸려고하는데, 너무 길다 싶으면 길이가 255 이상이면 임의길이까지 짜를지 고민입니다.

- 개발하면서 어떤 점이 궁금했는지
길이가 길어지면 화면에 어떻게 나오는지 궁금하네영...

## 📸 결과물 스크린샷
```java
결과 예시 사진 첨부
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- 
